### PR TITLE
Add property '__name__' to QuantizeAwareActivation layer

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/quantize_aware_activation.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/quantize_aware_activation.py
@@ -78,6 +78,10 @@ class QuantizeAwareActivation(object):
     self._min_post_activation, self._max_post_activation = \
       self._add_range_weights('post_activation')
 
+  @property
+  def __name__(self):
+      return self.activation.__name__
+
   def _is_keras_builtin_activation(self, activation):
     if not hasattr(activation, '__name__'):
       return False


### PR DESCRIPTION
Fixes error in tests quantize_test.py, quantize_functional_test.py and quantize_integration_test.py when using TF 1.14.0