### PR TITLE
Only install enum34 for Python <= 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ from version import __version__  # pylint: disable=g-import-not-at-top
 REQUIRED_PACKAGES = [
     'numpy~=1.14',
     'six~=1.10',
-    'enum34~=1.1',
+    'enum34~=1.1;python_version<"3.4"',
     'dm-tree~=0.1.1',
 ]
 


### PR DESCRIPTION
This is also how TensorFlow handles it: https://github.com/tensorflow/tensorflow/blob/6c8cbdceccce20f886a08b0cf00ac2e783ac524c/tensorflow/tools/pip_package/setup.py#L56