### PR TITLE
Fix bug in ClusterWrapper affecting stripping a selectively clustered model

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -198,7 +198,7 @@ def strip_clustering(model):
       # order of newly created weights
       layer.layer._trainable_weights = []
       layer.layer._non_trainable_weights = []
-      for i in range(layer.weights_num):
+      for i in range(len(layer.restore)):
         # This is why we used integers as keys
         name, weight = layer.restore[i]
         # In both cases we use k.batch_get_value since we need physical copies

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -115,9 +115,6 @@ class ClusterWeights(Wrapper):
     # comments in the code for usage explanations
     self.restore = []
 
-    # To restore the weight array after clustering is done
-    self.weights_num = len(self.layer.weights)
-
     # setattr will remove the original weights from layer.weights array. We need
     # to memorise the original state of the array since saving the model relies
     # on the variables order in layer.weights rather than on values stored in


### PR DESCRIPTION
This PR fixes a bug in `ClusterWrapper` that we came across when attempting to strip a selectively clustered model. In this particular use case we do not yet have access to `layer.weights` in `ClusterWrapper.__init__()`, therefore `self.weights_num` will end up being 0. This attribute was then used in `_strip_clustering_wrapper()` as the range of a for loop and thus we ended up skipping the weights. The fix removes the `self.weights_num` attribute and instead relies on `len(layer.restore)` in the stripping method.

The PR contains the bug fix itself, as well as a new unit tests for the selective clustering.