### PR TITLE
Improvements for selective clustering unit tests

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
@@ -131,7 +131,8 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
       cluster_wrapper.ClusterWeights(self.custom_non_clusterable_layer,
                                      **self.params)
 
-  def testClusterLayersSelectively(self):
+  @tf_test_util.run_in_graph_and_eager_modes
+  def testClusterSequentialModelSelectively(self):
     clustered_model = keras.Sequential()
     clustered_model.add(cluster.cluster_weights(self.keras_clusterable_layer, **self.params))
     clustered_model.add(self.keras_clusterable_layer)
@@ -139,6 +140,18 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
     self.assertIsInstance(clustered_model.layers[0], cluster_wrapper.ClusterWeights)
     self.assertNotIsInstance(clustered_model.layers[1], cluster_wrapper.ClusterWeights)
+
+  @tf_test_util.run_in_graph_and_eager_modes
+  def testClusterFunctionalModelSelectively(self):
+    i1 = keras.Input(shape=(10,))
+    i2 = keras.Input(shape=(10,))
+    x1 = cluster.cluster_weights(layers.Dense(10), **self.params)(i1)
+    x2 = layers.Dense(10)(i2)
+    outputs = layers.Add()([x1, x2])
+    clustered_model = keras.Model(inputs=[i1, i2], outputs=outputs)
+
+    self.assertIsInstance(clustered_model.layers[2], cluster_wrapper.ClusterWeights)
+    self.assertNotIsInstance(clustered_model.layers[3], cluster_wrapper.ClusterWeights)
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterModelValidLayersSuccessful(self):


### PR DESCRIPTION
This PR further improves the test coverage of selective clustering. It contains the following changes:
- Renamed `testClusterLayersSelectively()` to `testClusterSequentialModelSelectively()` to better reflect the precise use case being tested
- Added new unit test `testClusterFunctionalModelSelectively()` to cover the previously untested use case of selectively clustering a functional model
- Added `@tf_test_util.run_in_graph_and_eager_modes` annotation to all selective clustering unit tests in order to ensure that they are run in both modes