### PR TITLE
Move clustering end-to-end test into separate file

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/BUILD
+++ b/tensorflow_model_optimization/python/core/clustering/keras/BUILD
@@ -113,3 +113,15 @@ py_test(
         # tensorflow dep1,
     ],
 )
+
+py_test(
+    name = "cluster_integration_test",
+    size = "medium",
+    srcs = ["cluster_integration_test.py"],
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cluster",
+        # tensorflow dep1,
+    ],
+)

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -1,0 +1,77 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""End-to-end tests for keras clustering API."""
+
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow_model_optimization.python.core.clustering.keras import cluster
+
+
+keras = tf.keras
+layers = keras.layers
+test = tf.test
+
+
+class ClusterIntegrationTest(test.TestCase):
+
+  @tf_test_util.run_in_graph_and_eager_modes
+  def testValuesRemainClusteredAfterTraining(self):
+    number_of_clusters = 10
+    original_model = keras.Sequential([
+        layers.Dense(2, input_shape=(2,)),
+        layers.Dense(2),
+    ])
+
+    clustered_model = cluster.cluster_weights(
+        original_model,
+        number_of_clusters=number_of_clusters,
+        cluster_centroids_init='linear'
+    )
+
+    clustered_model.compile(
+        loss=keras.losses.categorical_crossentropy,
+        optimizer='adam',
+        metrics=['accuracy']
+    )
+
+    def dataset_generator():
+      x_train = np.array([
+          [0, 1],
+          [2, 0],
+          [0, 3],
+          [4, 1],
+          [5, 1],
+      ])
+      y_train = np.array([
+          [0, 1],
+          [1, 0],
+          [1, 0],
+          [0, 1],
+          [0, 1],
+      ])
+      for x, y in zip(x_train, y_train):
+        yield np.array([x]), np.array([y])
+
+    clustered_model.fit_generator(dataset_generator(), steps_per_epoch=1)
+    stripped_model = cluster.strip_clustering(clustered_model)
+    weights_as_list = stripped_model.get_weights()[0].reshape(-1,).tolist()
+    unique_weights = set(weights_as_list)
+    self.assertLessEqual(len(unique_weights), number_of_clusters)
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
@@ -131,48 +131,6 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
     # Make sure that the stripped layer is the Dense one
     self.assertIsInstance(stripped_model.layers[0], layers.Dense)
 
-  @tf_test_util.run_in_graph_and_eager_modes
-  def testValuesRemainClusteredAfterTraining(self):
-    number_of_clusters = 10
-    original_model = tf.keras.Sequential([
-        layers.Dense(2, input_shape=(2,)),
-        layers.Dense(2),
-    ])
-    clustered_model = cluster.cluster_weights(
-        original_model,
-        number_of_clusters=number_of_clusters,
-        cluster_centroids_init='linear'
-    )
-
-    clustered_model.compile(
-        loss=tf.keras.losses.categorical_crossentropy,
-        optimizer='adam',
-        metrics=['accuracy']
-    )
-
-    def dataset_generator():
-      x_train = np.array([
-          [0, 1],
-          [2, 0],
-          [0, 3],
-          [4, 1],
-          [5, 1],
-      ])
-      y_train = np.array([
-          [0, 1],
-          [1, 0],
-          [1, 0],
-          [0, 1],
-          [0, 1],
-      ])
-      for x, y in zip(x_train, y_train):
-        yield np.array([x]), np.array([y])
-
-    clustered_model.fit_generator(dataset_generator(), steps_per_epoch=1)
-    stripped_model = cluster.strip_clustering(clustered_model)
-    weights_as_list = stripped_model.get_weights()[0].reshape(-1,).tolist()
-    unique_weights = set(weights_as_list)
-    self.assertLessEqual(len(unique_weights), number_of_clusters)
 
 if __name__ == '__main__':
   tf.disable_v2_behavior()


### PR DESCRIPTION
This PR addresses the proposal raised in [this comment](https://github.com/tensorflow/model-optimization/pull/125#discussion_r363539787) and moves `testValuesRemainClusteredAfterTraining()` from `cluster_wrapper_test.py` into a separate file named `cluster_integration_test.py`.