### PR TITLE
Added docstrings to clustering tests

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -27,9 +27,13 @@ test = tf.test
 
 
 class ClusterIntegrationTest(test.TestCase):
+  """Integration tests for clustering."""
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testValuesRemainClusteredAfterTraining(self):
+    """
+    Verifies that training a clustered model does not destroy the clusters.
+    """
     number_of_clusters = 10
     original_model = keras.Sequential([
         layers.Dense(2, input_shape=(2,)),

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
@@ -54,6 +54,7 @@ class CustomNonClusterableLayer(layers.Dense):
 
 
 class ClusterTest(test.TestCase, parameterized.TestCase):
+  """Unit tests for the cluster module."""
 
   def setUp(self):
     super(ClusterTest, self).setUp()
@@ -99,6 +100,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterKerasClusterableLayer(self):
+    """
+    Verifies that a built-in keras layer marked as clusterable is being
+    clustered correctly.
+    """
     wrapped_layer = self._build_clustered_layer_model(
         self.keras_clusterable_layer)
 
@@ -106,6 +111,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterKerasNonClusterableLayer(self):
+    """
+    Verifies that a built-in keras layer not marked as clusterable is
+    not being clustered.
+    """
     wrapped_layer = self._build_clustered_layer_model(
         self.keras_non_clusterable_layer)
 
@@ -114,11 +123,18 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertEqual([], wrapped_layer.layer.get_clusterable_weights())
 
   def testClusterKerasUnsupportedLayer(self):
+    """
+    Verifies that attempting to cluster an unsupported layer raises an
+    exception.
+    """
     with self.assertRaises(ValueError):
       cluster.cluster_weights(self.keras_unsupported_layer, **self.params)
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterCustomClusterableLayer(self):
+    """
+    Verifies that a custom clusterable layer is being clustered correctly.
+    """
     wrapped_layer = self._build_clustered_layer_model(
         self.custom_clusterable_layer)
 
@@ -127,12 +143,20 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
                      wrapped_layer.layer.get_clusterable_weights())
 
   def testClusterCustomNonClusterableLayer(self):
+    """
+    Verifies that attempting to cluster a custom non-clusterable layer raises
+    an exception.
+    """
     with self.assertRaises(ValueError):
       cluster_wrapper.ClusterWeights(self.custom_non_clusterable_layer,
                                      **self.params)
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterSequentialModelSelectively(self):
+    """
+    Verifies that layers within a sequential model can be clustered
+    selectively.
+    """
     clustered_model = keras.Sequential()
     clustered_model.add(cluster.cluster_weights(self.keras_clusterable_layer, **self.params))
     clustered_model.add(self.keras_clusterable_layer)
@@ -143,6 +167,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterFunctionalModelSelectively(self):
+    """
+    Verifies that layers within a functional model can be clustered
+    selectively.
+    """
     i1 = keras.Input(shape=(10,))
     i2 = keras.Input(shape=(10,))
     x1 = cluster.cluster_weights(layers.Dense(10), **self.params)(i1)
@@ -155,6 +183,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterModelValidLayersSuccessful(self):
+    """
+    Verifies that clustering a sequential model results in all clusterable
+    layers within the model being clustered.
+    """
     model = keras.Sequential([
         self.keras_clusterable_layer,
         self.keras_non_clusterable_layer,
@@ -168,6 +200,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
       self._validate_clustered_layer(layer, clustered_layer)
 
   def testClusterModelUnsupportedKerasLayerRaisesError(self):
+    """
+    Verifies that attempting to cluster a model that contains an unsupported
+    layer raises an exception.
+    """
     with self.assertRaises(ValueError):
       cluster.cluster_weights(
           keras.Sequential([
@@ -176,6 +212,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
           ]), **self.params)
 
   def testClusterModelCustomNonClusterableLayerRaisesError(self):
+    """
+    Verifies that attempting to cluster a model that contains a custom
+    non-clusterable layer raises an exception.
+    """
     with self.assertRaises(ValueError):
       cluster.cluster_weights(
           keras.Sequential([
@@ -185,6 +225,11 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterModelDoesNotWrapAlreadyWrappedLayer(self):
+    """
+    Verifies that clustering a model that contains an already clustered layer
+    does not result in wrapping the clustered layer into another
+    cluster_wrapper.
+    """
     model = keras.Sequential(
         [
             layers.Flatten(),
@@ -201,6 +246,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
                                    clustered_model.layers[1])
 
   def testClusterValidLayersListSuccessful(self):
+    """
+    Verifies that clustering a list of layers results in all clusterable
+    layers within the list being clustered.
+    """
     model_layers = [
         self.keras_clusterable_layer,
         self.keras_non_clusterable_layer,
@@ -213,6 +262,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
       self._validate_clustered_layer(layer, clustered_layer)
 
   def testClusterSequentialModelNoInput(self):
+    """
+    Verifies that a sequential model without an input layer is being clustered
+    correctly.
+    """
     # No InputLayer
     model = keras.Sequential([
         layers.Dense(10),
@@ -223,6 +276,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterSequentialModelWithInput(self):
+    """
+    Verifies that a sequential model with an input layer is being clustered
+    correctly.
+    """
     # With InputLayer
     model = keras.Sequential([
         layers.Dense(10, input_shape=(10,)),
@@ -232,6 +289,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertEqual(self._count_clustered_layers(clustered_model), 2)
 
   def testClusterSequentialModelPreservesBuiltStateNoInput(self):
+    """
+    Verifies that clustering a sequential model without an input layer
+    preserves the built state of the model.
+    """
     # No InputLayer
     model = keras.Sequential([
         layers.Dense(10),
@@ -249,6 +310,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterSequentialModelPreservesBuiltStateWithInput(self):
+    """
+    Verifies that clustering a sequential model with an input layer preserves
+    the built state of the model.
+    """
     # With InputLayer
     model = keras.Sequential([
         layers.Dense(10, input_shape=(10,)),
@@ -266,6 +331,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterFunctionalModelPreservesBuiltState(self):
+    """
+    Verifies that clustering a functional model preserves the built state of
+    the model.
+    """
     i1 = keras.Input(shape=(10,))
     i2 = keras.Input(shape=(10,))
     x1 = layers.Dense(10)(i1)
@@ -284,6 +353,9 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterFunctionalModel(self):
+    """
+    Verifies that a functional model is being clustered correctly.
+    """
     i1 = keras.Input(shape=(10,))
     i2 = keras.Input(shape=(10,))
     x1 = layers.Dense(10)(i1)
@@ -295,6 +367,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterFunctionalModelWithLayerReused(self):
+    """
+    Verifies that a layer reused within a functional model multiple times is
+    only being clustered once.
+    """
     # The model reuses the Dense() layer. Make sure it's only clustered once.
     inp = keras.Input(shape=(10,))
     dense_layer = layers.Dense(10)
@@ -306,12 +382,20 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterSubclassModel(self):
+    """
+    Verifies that attempting to cluster an instance of a subclass of
+    keras.Model raises an exception.
+    """
     model = TestModel()
     with self.assertRaises(ValueError):
       _ = cluster.cluster_weights(model, **self.params)
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testStripClusteringSequentialModel(self):
+    """
+    Verifies that stripping the clustering wrappers from a sequential model
+    produces the expected config.
+    """
     model = keras.Sequential([
         layers.Dense(10),
         layers.Dense(10),
@@ -325,6 +409,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterStrippingFunctionalModel(self):
+    """
+    Verifies that stripping the clustering wrappers from a functional model
+    produces the expected config.
+    """
     i1 = keras.Input(shape=(10,))
     i2 = keras.Input(shape=(10,))
     x1 = layers.Dense(10)(i1)
@@ -340,6 +428,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testClusterWeightsStrippedWeights(self):
+    """
+    Verifies that stripping the clustering wrappers from a functional model
+    preserves the clustered weights.
+    """
     i1 = keras.Input(shape=(10,))
     x1 = layers.BatchNormalization()(i1)
     outputs = x1
@@ -354,6 +446,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testStripSelectivelyClusteredFunctionalModel(self):
+    """
+    Verifies that invoking strip_clustering() on a selectively clustered
+    functional model strips the clustering wrappers from the clustered layers.
+    """
     i1 = keras.Input(shape=(10,))
     i2 = keras.Input(shape=(10,))
     x1 = cluster.cluster_weights(layers.Dense(10), **self.params)(i1)
@@ -368,6 +464,10 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def testStripSelectivelyClusteredSequentialModel(self):
+    """
+    Verifies that invoking strip_clustering() on a selectively clustered
+    sequential model strips the clustering wrappers from the clustered layers.
+    """
     clustered_model = keras.Sequential([
       cluster.cluster_weights(layers.Dense(10), **self.params),
       layers.Dense(10),

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
@@ -38,42 +38,64 @@ ClusteringLookupRegistry = clustering_registry.ClusteringLookupRegistry
 
 
 class NonClusterableLayer(layers.Dense):
-  pass
+  """A custom layer that is not clusterable."""
 
 
 class AlreadyClusterableLayer(layers.Dense, clusterable_layer.ClusterableLayer):
+  """A custom layer that is clusterable."""
 
   def get_clusterable_weights(self):
     pass
 
 
 class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
+  """Unit tests for the cluster_wrapper module."""
 
   def testCannotBeInitializedWithNonLayerObject(self):
+    """
+    Verifies that ClusterWeights cannot be initialized with an object that is
+    not an instance of keras.layers.Layer.
+    """
     with self.assertRaises(ValueError):
       cluster_wrapper.ClusterWeights({
           'this': 'is not a Layer instance'
       }, number_of_clusters=13, cluster_centroids_init='linear')
 
   def testCannotBeInitializedWithNonClusterableLayer(self):
+    """
+    Verifies that ClusterWeights cannot be initialized with a non-clusterable
+    custom layer.
+    """
     with self.assertRaises(ValueError):
       cluster_wrapper.ClusterWeights(NonClusterableLayer(10),
                                      number_of_clusters=13,
                                      cluster_centroids_init='linear')
 
   def testCanBeInitializedWithClusterableLayer(self):
+    """
+    Verifies that ClusterWeights can be initialized with a built-in clusterable
+    layer.
+    """
     l = cluster_wrapper.ClusterWeights(layers.Dense(10),
                                        number_of_clusters=13,
                                        cluster_centroids_init='linear')
     self.assertIsInstance(l, cluster_wrapper.ClusterWeights)
 
   def testCannotBeInitializedWithNonIntegerNumberOfClusters(self):
+    """
+    Verifies that ClusterWeights cannot be initialized with a string value
+    provided for the number of clusters.
+    """
     with self.assertRaises(ValueError):
       cluster_wrapper.ClusterWeights(layers.Dense(10),
                                      number_of_clusters="13",
                                      cluster_centroids_init='linear')
 
   def testCannotBeInitializedWithFloatNumberOfClusters(self):
+    """
+    Verifies that ClusterWeights cannot be initialized with a decimal value
+    provided for the number of clusters.
+    """
     with self.assertRaises(ValueError):
       cluster_wrapper.ClusterWeights(layers.Dense(10),
                                      number_of_clusters=13.4,
@@ -86,12 +108,20 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
   )
   def testCannotBeInitializedWithNumberOfClustersLessThanTwo(
       self, number_of_clusters):
+    """
+    Verifies that ClusterWeights cannot be initialized with less than two
+    clusters.
+    """
     with self.assertRaises(ValueError):
       cluster_wrapper.ClusterWeights(layers.Dense(10),
                                      number_of_clusters=number_of_clusters,
                                      cluster_centroids_init='linear')
 
   def testCanBeInitializedWithAlreadyClusterableLayer(self):
+    """
+    Verifies that ClusterWeights can be initialized with a custom clusterable
+    layer.
+    """
     layer = AlreadyClusterableLayer(10)
     l = cluster_wrapper.ClusterWeights(layer,
                                        number_of_clusters=13,
@@ -99,6 +129,10 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
     self.assertIsInstance(l, cluster_wrapper.ClusterWeights)
 
   def testIfLayerHasBatchShapeClusterWeightsMustHaveIt(self):
+    """
+    Verifies that the ClusterWeights instance created from a layer that has
+    a batch shape attribute, will also have this attribute.
+    """
     l = cluster_wrapper.ClusterWeights(layers.Dense(10, input_shape=(10,)),
                                        number_of_clusters=13,
                                        cluster_centroids_init='linear')
@@ -111,9 +145,11 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
   def testValuesAreClusteredAfterStripping(self,
                                            number_of_clusters,
                                            cluster_centroids_init):
-    # We want to make sure that for any number of clusters and any
-    # initializations methods there is always no more than number_of_clusters
-    # unique points after stripping the model
+    """
+    Verifies that, for any number of clusters and any centroid initialization
+    method, the number of unique weight values after stripping is always less
+    or equal to number_of_clusters.
+    """
     original_model = tf.keras.Sequential([
         layers.Dense(32, input_shape=(10,)),
     ])

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
@@ -28,6 +28,7 @@ test = tf.test
 
 
 class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
+  """Unit tests for the clustering_centroids module."""
 
   def setUp(self):
     self.factory = clustering_centroids.CentroidsInitializerFactory
@@ -38,6 +39,9 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       ('density-based'),
   )
   def testExistingInitsAreSupported(self, init_type):
+    """
+    Verifies that the given centroid initialization methods are supported.
+    """
     self.assertTrue(self.factory.init_is_supported(init_type))
 
   def testNonExistingInitIsNotSupported(self):
@@ -52,9 +56,17 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       ),
   )
   def testReturnsMethodForExistingInit(self, init_type, method):
+    """
+    Verifies that the centroid initializer factory method returns the expected
+    classes for the given initialization methods.
+    """
     self.assertEqual(self.factory.get_centroid_initializer(init_type), method)
 
   def testThrowsValueErrorForNonExistingInit(self):
+    """
+    Verifies that the centroid initializer factory method raises an exception
+    when invoked with an unsupported initialization method.
+    """
     with self.assertRaises(ValueError):
       self.factory.get_centroid_initializer("DEADBEEF")
 
@@ -66,6 +78,9 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       (-5, 4, 7, 10, 1.0 / 2.0, 13.0 / 2.0),
   )
   def testLinearSolverConstruction(self, x1, y1, x2, y2, a, b):
+    """
+    Verifies that a TFLinearEquationSolver is constructed correctly.
+    """
     solver = clustering_centroids.TFLinearEquationSolver(float(x1),
                                                          float(y1),
                                                          float(x2),
@@ -81,6 +96,10 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       (7, 12, 17, 22, 3, 8),
   )
   def testLinearSolverSolveForX(self, x1, y1, x2, y2, x, y):
+    """
+    Verifies that TFLinearEquationSolver solves the given equations correctly
+    for X.
+    """
     solver = clustering_centroids.TFLinearEquationSolver(float(x1),
                                                          float(y1),
                                                          float(x2),
@@ -95,6 +114,10 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       (7, 12, 17, 22, 3, 8),
   )
   def testLinearSolverSolveForY(self, x1, y1, x2, y2, x, y):
+    """
+    Verifies that TFLinearEquationSolver solves the given equations correctly
+    for Y.
+    """
     solver = clustering_centroids.TFLinearEquationSolver(float(x1),
                                                          float(y1),
                                                          float(x2),
@@ -110,6 +133,10 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       ([1, 2, 3, 4, 5, 6, 7, 8, 9], -20, 0.)
   )
   def testCDFValues(self, weights, point, probability):
+    """
+    Verifies that TFCumulativeDistributionFunction yields the expected output
+    for the inputs provided.
+    """
     cdf_calc = clustering_centroids.TFCumulativeDistributionFunction(weights)
     self.assertAlmostEqual(
         probability,


### PR DESCRIPTION
This PR improves the documentation of the clustering tests by adding docstrings that explain what each test is supposed to verify. 