### PR TITLE
Remove private API dependencies from clustering

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -14,12 +14,11 @@
 # ==============================================================================
 """Clustering API functions for Keras models."""
 
-from tensorflow.python import keras
-from tensorflow.python.keras import backend as k
-from tensorflow.python.keras import initializers
-from tensorflow.python.keras.engine.base_layer import Layer
-from tensorflow.python.keras.engine.input_layer import InputLayer
-from tensorflow.python.keras.utils.generic_utils import custom_object_scope
+from tensorflow import keras
+from tensorflow.keras import backend as k
+from tensorflow.keras import initializers
+from tensorflow.keras.layers import Layer, InputLayer
+from tensorflow.keras.utils import CustomObjectScope
 
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_wrapper
@@ -44,7 +43,7 @@ def cluster_scope():
     loaded_model = keras.models.load_model(keras_file)
   ```
   """
-  return custom_object_scope(
+  return CustomObjectScope(
       {
           'ClusterWeights': cluster_wrapper.ClusterWeights
       }

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -15,13 +15,15 @@
 """Clustering API functions for Keras models."""
 
 from tensorflow import keras
-from tensorflow.keras import backend as k
 from tensorflow.keras import initializers
-from tensorflow.keras.layers import Layer, InputLayer
-from tensorflow.keras.utils import CustomObjectScope
 
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_wrapper
+
+k = keras.backend
+CustomObjectScope = keras.utils.CustomObjectScope
+Layer = keras.layers.Layer
+InputLayer = keras.layers.InputLayer
 
 
 def cluster_scope():

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -15,9 +15,10 @@
 """End-to-end tests for keras clustering API."""
 
 import numpy as np
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
 
-from tensorflow.python.framework import test_util as tf_test_util
+from absl.testing import parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow_model_optimization.python.core.clustering.keras import cluster
 
 
@@ -26,10 +27,10 @@ layers = keras.layers
 test = tf.test
 
 
-class ClusterIntegrationTest(test.TestCase):
+class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
   """Integration tests for clustering."""
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testValuesRemainClusteredAfterTraining(self):
     """
     Verifies that training a clustered model does not destroy the clusters.

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -21,7 +21,6 @@ from absl.testing import parameterized
 from tensorflow.python.keras import keras_parameterized
 from tensorflow_model_optimization.python.core.clustering.keras import cluster
 
-
 keras = tf.keras
 layers = keras.layers
 test = tf.test

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
@@ -15,16 +15,15 @@
 """Tests for keras clustering API."""
 
 import json
+import tensorflow as tf
+
+from absl.testing import parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from tensorflow_model_optimization.python.core.clustering.keras import cluster
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_wrapper
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
-
-from tensorflow.python.framework import test_util as tf_test_util
-
-import tensorflow.compat.v1 as tf
-from absl.testing import parameterized
 
 keras = tf.keras
 errors_impl = tf.errors
@@ -98,7 +97,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
         count += 1
     return count
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterKerasClusterableLayer(self):
     """
     Verifies that a built-in keras layer marked as clusterable is being
@@ -109,7 +108,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
 
     self._validate_clustered_layer(self.keras_clusterable_layer, wrapped_layer)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterKerasNonClusterableLayer(self):
     """
     Verifies that a built-in keras layer not marked as clusterable is
@@ -130,7 +129,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     with self.assertRaises(ValueError):
       cluster.cluster_weights(self.keras_unsupported_layer, **self.params)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterCustomClusterableLayer(self):
     """
     Verifies that a custom clusterable layer is being clustered correctly.
@@ -151,7 +150,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
       cluster_wrapper.ClusterWeights(self.custom_non_clusterable_layer,
                                      **self.params)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterSequentialModelSelectively(self):
     """
     Verifies that layers within a sequential model can be clustered
@@ -165,7 +164,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertIsInstance(clustered_model.layers[0], cluster_wrapper.ClusterWeights)
     self.assertNotIsInstance(clustered_model.layers[1], cluster_wrapper.ClusterWeights)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterFunctionalModelSelectively(self):
     """
     Verifies that layers within a functional model can be clustered
@@ -181,7 +180,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertIsInstance(clustered_model.layers[2], cluster_wrapper.ClusterWeights)
     self.assertNotIsInstance(clustered_model.layers[3], cluster_wrapper.ClusterWeights)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterModelValidLayersSuccessful(self):
     """
     Verifies that clustering a sequential model results in all clusterable
@@ -223,7 +222,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
               self.custom_clusterable_layer, self.custom_non_clusterable_layer
           ]), **self.params)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterModelDoesNotWrapAlreadyWrappedLayer(self):
     """
     Verifies that clustering a model that contains an already clustered layer
@@ -274,7 +273,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     clustered_model = cluster.cluster_weights(model, **self.params)
     self.assertEqual(self._count_clustered_layers(clustered_model), 2)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterSequentialModelWithInput(self):
     """
     Verifies that a sequential model with an input layer is being clustered
@@ -308,7 +307,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
           json.loads(clustered_model.to_json()))
       self.assertEqual(loaded_model.built, False)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterSequentialModelPreservesBuiltStateWithInput(self):
     """
     Verifies that clustering a sequential model with an input layer preserves
@@ -329,7 +328,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
           json.loads(clustered_model.to_json()))
     self.assertEqual(loaded_model.built, True)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterFunctionalModelPreservesBuiltState(self):
     """
     Verifies that clustering a functional model preserves the built state of
@@ -351,7 +350,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
           json.loads(clustered_model.to_json()))
     self.assertEqual(loaded_model.built, True)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterFunctionalModel(self):
     """
     Verifies that a functional model is being clustered correctly.
@@ -365,7 +364,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     clustered_model = cluster.cluster_weights(model, **self.params)
     self.assertEqual(self._count_clustered_layers(clustered_model), 3)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterFunctionalModelWithLayerReused(self):
     """
     Verifies that a layer reused within a functional model multiple times is
@@ -380,7 +379,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     clustered_model = cluster.cluster_weights(model, **self.params)
     self.assertEqual(self._count_clustered_layers(clustered_model), 1)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterSubclassModel(self):
     """
     Verifies that attempting to cluster an instance of a subclass of
@@ -390,7 +389,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     with self.assertRaises(ValueError):
       _ = cluster.cluster_weights(model, **self.params)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testStripClusteringSequentialModel(self):
     """
     Verifies that stripping the clustering wrappers from a sequential model
@@ -407,7 +406,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertEqual(self._count_clustered_layers(stripped_model), 0)
     self.assertEqual(model.get_config(), stripped_model.get_config())
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterStrippingFunctionalModel(self):
     """
     Verifies that stripping the clustering wrappers from a functional model
@@ -426,7 +425,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertEqual(self._count_clustered_layers(stripped_model), 0)
     self.assertEqual(model.get_config(), stripped_model.get_config())
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testClusterWeightsStrippedWeights(self):
     """
     Verifies that stripping the clustering wrappers from a functional model
@@ -444,7 +443,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertEqual(self._count_clustered_layers(stripped_model), 0)
     self.assertEqual(len(stripped_model.get_weights()), cluster_weight_length)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testStripSelectivelyClusteredFunctionalModel(self):
     """
     Verifies that invoking strip_clustering() on a selectively clustered
@@ -462,7 +461,7 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertEqual(self._count_clustered_layers(stripped_model), 0)
     self.assertIsInstance(stripped_model.layers[2], layers.Dense)
 
-  @tf_test_util.run_in_graph_and_eager_modes
+  @keras_parameterized.run_all_keras_modes
   def testStripSelectivelyClusteredSequentialModel(self):
     """
     Verifies that invoking strip_clustering() on a selectively clustered
@@ -480,5 +479,4 @@ class ClusterTest(test.TestCase, parameterized.TestCase):
     self.assertIsInstance(stripped_model.layers[0], layers.Dense)
 
 if __name__ == '__main__':
-  tf.disable_v2_behavior()
   test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_test.py
@@ -30,6 +30,7 @@ errors_impl = tf.errors
 layers = keras.layers
 test = tf.test
 
+
 class TestModel(keras.Model):
   """A model subclass."""
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -14,14 +14,13 @@
 # ==============================================================================
 """Keras ClusterWeights wrapper API."""
 
-import tensorflow.compat.v1 as tf
-from tensorflow.python.keras import initializers, backend as k
-from tensorflow.python.keras.layers import Wrapper
+import tensorflow as tf
+
+from tensorflow.keras import initializers, backend as k
+from tensorflow.keras.layers import Layer, Wrapper
 
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer, clustering_registry, \
   clustering_centroids
-
-Layer = tf.keras.layers.Layer
 
 
 class ClusterWeights(Wrapper):

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -16,11 +16,16 @@
 
 import tensorflow as tf
 
-from tensorflow.keras import initializers, backend as k
-from tensorflow.keras.layers import Layer, Wrapper
+from tensorflow.keras import initializers
 
-from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer, clustering_registry, \
-  clustering_centroids
+from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
+from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
+from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
+
+keras = tf.keras
+k = keras.backend
+Layer = keras.layers.Layer
+Wrapper = keras.layers.Wrapper
 
 
 class ClusterWeights(Wrapper):

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
@@ -16,16 +16,14 @@
 
 import itertools
 import numpy as np
+import tensorflow as tf
+
+from absl.testing import parameterized
 
 from tensorflow_model_optimization.python.core.clustering.keras import cluster
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_wrapper
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
-
-from tensorflow.python.framework import test_util as tf_test_util
-
-import tensorflow.compat.v1 as tf
-from absl.testing import parameterized
 
 keras = tf.keras
 errors_impl = tf.errors
@@ -169,5 +167,4 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
 
 
 if __name__ == '__main__':
-  tf.disable_v2_behavior()
   test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/clusterable_layer.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clusterable_layer.py
@@ -15,7 +15,6 @@
 """Clusterable layer API class for Keras models."""
 
 import abc
-
 import six
 
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
@@ -15,9 +15,9 @@
 """Clusters centroids initialization API for Keras clustering API."""
 
 import abc
-
 import six
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
+
 from tensorflow.python.keras import backend as k
 
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
@@ -18,7 +18,7 @@ import abc
 import six
 import tensorflow as tf
 
-from tensorflow.python.keras import backend as k
+k = tf.keras.backend
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
@@ -14,12 +14,12 @@
 # ==============================================================================
 """Tests for keras clustering centroids initialisation API."""
 
-from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
-
-import tensorflow.compat.v1 as tf
-import tensorflow.compat.v1.keras.backend as K
+import tensorflow as tf
+import tensorflow.keras.backend as K
 
 from absl.testing import parameterized
+
+from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
 
 keras = tf.keras
 errors_impl = tf.errors

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
@@ -15,10 +15,10 @@
 """Registry responsible for built-in keras classes."""
 
 import abc
-
 import six
-import tensorflow.compat.v1 as tf
-from tensorflow.python.keras import layers
+import tensorflow as tf
+
+from tensorflow.keras import layers
 
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
 
@@ -150,21 +150,18 @@ class ClusteringLookupRegistry(object):
   work on, or the strategy is not currently supported
   """
   _LAYERS_RESHAPE_MAP = {
-      layers.convolutional.Conv1D: {'kernel': ConvolutionalWeightsCA},
-      layers.convolutional.Conv2D: {'kernel': ConvolutionalWeightsCA},
-      layers.convolutional.Conv2DTranspose: {'kernel': ConvolutionalWeightsCA},
-      layers.convolutional.Conv3D: {'kernel': ConvolutionalWeightsCA},
-      layers.convolutional.Conv3DTranspose: {'kernel': ConvolutionalWeightsCA},
-      layers.convolutional.DepthwiseConv2D: {
-          'depthwise_kernel': ConvolutionalWeightsCA},
-      layers.convolutional.SeparableConv1D: {
-          'pointwise_kernel': ConvolutionalWeightsCA},
-      layers.convolutional.SeparableConv2D: {
-          'pointwise_kernel': ConvolutionalWeightsCA},
-      layers.core.Dense: {'kernel': DenseWeightsCA},
-      layers.embeddings.Embedding: {'embeddings': DenseWeightsCA},
-      layers.local.LocallyConnected1D: {'kernel': ConvolutionalWeightsCA},
-      layers.local.LocallyConnected2D: {'kernel': ConvolutionalWeightsCA},
+      layers.Conv1D: {'kernel': ConvolutionalWeightsCA},
+      layers.Conv2D: {'kernel': ConvolutionalWeightsCA},
+      layers.Conv2DTranspose: {'kernel': ConvolutionalWeightsCA},
+      layers.Conv3D: {'kernel': ConvolutionalWeightsCA},
+      layers.Conv3DTranspose: {'kernel': ConvolutionalWeightsCA},
+      layers.DepthwiseConv2D: {'depthwise_kernel': ConvolutionalWeightsCA},
+      layers.SeparableConv1D: {'pointwise_kernel': ConvolutionalWeightsCA},
+      layers.SeparableConv2D: {'pointwise_kernel': ConvolutionalWeightsCA},
+      layers.Dense: {'kernel': DenseWeightsCA},
+      layers.Embedding: {'embeddings': DenseWeightsCA},
+      layers.LocallyConnected1D: {'kernel': ConvolutionalWeightsCA},
+      layers.LocallyConnected2D: {'kernel': ConvolutionalWeightsCA},
   }
 
   @classmethod
@@ -234,83 +231,94 @@ class ClusteringRegistry(object):
   # the variables within the layers which hold the kernel weights. This
   # allows the wrapper to access and modify the weights.
   _LAYERS_WEIGHTS_MAP = {
-      layers.advanced_activations.ELU: [],
-      layers.advanced_activations.LeakyReLU: [],
-      layers.advanced_activations.ReLU: [],
-      layers.advanced_activations.Softmax: [],
-      layers.advanced_activations.ThresholdedReLU: [],
-      layers.convolutional.Conv1D: ['kernel'],
-      layers.convolutional.Conv2D: ['kernel'],
-      layers.convolutional.Conv2DTranspose: ['kernel'],
-      layers.convolutional.Conv3D: ['kernel'],
-      layers.convolutional.Conv3DTranspose: ['kernel'],
-      layers.convolutional.Cropping1D: [],
-      layers.convolutional.Cropping2D: [],
-      layers.convolutional.Cropping3D: [],
-      layers.convolutional.DepthwiseConv2D: ['depthwise_kernel'],
-      layers.convolutional.SeparableConv1D: ['pointwise_kernel'],
-      layers.convolutional.SeparableConv2D: ['pointwise_kernel'],
-      layers.convolutional.UpSampling1D: [],
-      layers.convolutional.UpSampling2D: [],
-      layers.convolutional.UpSampling3D: [],
-      layers.convolutional.ZeroPadding1D: [],
-      layers.convolutional.ZeroPadding2D: [],
-      layers.convolutional.ZeroPadding3D: [],
-      layers.core.Activation: [],
-      layers.core.ActivityRegularization: [],
-      layers.core.Dense: ['kernel'],
-      layers.core.Dropout: [],
-      layers.core.Flatten: [],
-      layers.core.Lambda: [],
-      layers.core.Masking: [],
-      layers.core.Permute: [],
-      layers.core.RepeatVector: [],
-      layers.core.Reshape: [],
-      layers.core.SpatialDropout1D: [],
-      layers.core.SpatialDropout2D: [],
-      layers.core.SpatialDropout3D: [],
-      layers.embeddings.Embedding: ['embeddings'],
-      layers.local.LocallyConnected1D: ['kernel'],
-      layers.local.LocallyConnected2D: ['kernel'],
-      layers.merge.Add: [],
-      layers.merge.Average: [],
-      layers.merge.Concatenate: [],
-      layers.merge.Dot: [],
-      layers.merge.Maximum: [],
-      layers.merge.Minimum: [],
-      layers.merge.Multiply: [],
-      layers.merge.Subtract: [],
-      layers.noise.AlphaDropout: [],
-      layers.noise.GaussianDropout: [],
-      layers.noise.GaussianNoise: [],
-      layers.normalization.BatchNormalization: [],
-      layers.normalization.LayerNormalization: [],
-      layers.pooling.AveragePooling1D: [],
-      layers.pooling.AveragePooling2D: [],
-      layers.pooling.AveragePooling3D: [],
-      layers.pooling.GlobalAveragePooling1D: [],
-      layers.pooling.GlobalAveragePooling2D: [],
-      layers.pooling.GlobalAveragePooling3D: [],
-      layers.pooling.GlobalMaxPooling1D: [],
-      layers.pooling.GlobalMaxPooling2D: [],
-      layers.pooling.GlobalMaxPooling3D: [],
-      layers.pooling.MaxPooling1D: [],
-      layers.pooling.MaxPooling2D: [],
-      layers.pooling.MaxPooling3D: [],
+      layers.ELU: [],
+      layers.LeakyReLU: [],
+      layers.ReLU: [],
+      layers.Softmax: [],
+      layers.ThresholdedReLU: [],
+      layers.Conv1D: ['kernel'],
+      layers.Conv2D: ['kernel'],
+      layers.Conv2DTranspose: ['kernel'],
+      layers.Conv3D: ['kernel'],
+      layers.Conv3DTranspose: ['kernel'],
+      layers.Cropping1D: [],
+      layers.Cropping2D: [],
+      layers.Cropping3D: [],
+      layers.DepthwiseConv2D: ['depthwise_kernel'],
+      layers.SeparableConv1D: ['pointwise_kernel'],
+      layers.SeparableConv2D: ['pointwise_kernel'],
+      layers.UpSampling1D: [],
+      layers.UpSampling2D: [],
+      layers.UpSampling3D: [],
+      layers.ZeroPadding1D: [],
+      layers.ZeroPadding2D: [],
+      layers.ZeroPadding3D: [],
+      layers.Activation: [],
+      layers.ActivityRegularization: [],
+      layers.Dense: ['kernel'],
+      layers.Dropout: [],
+      layers.Flatten: [],
+      layers.Lambda: [],
+      layers.Masking: [],
+      layers.Permute: [],
+      layers.RepeatVector: [],
+      layers.Reshape: [],
+      layers.SpatialDropout1D: [],
+      layers.SpatialDropout2D: [],
+      layers.SpatialDropout3D: [],
+      layers.Embedding: ['embeddings'],
+      layers.LocallyConnected1D: ['kernel'],
+      layers.LocallyConnected2D: ['kernel'],
+      layers.Add: [],
+      layers.Average: [],
+      layers.Concatenate: [],
+      layers.Dot: [],
+      layers.Maximum: [],
+      layers.Minimum: [],
+      layers.Multiply: [],
+      layers.Subtract: [],
+      layers.AlphaDropout: [],
+      layers.GaussianDropout: [],
+      layers.GaussianNoise: [],
+      layers.BatchNormalization: [],
+      layers.LayerNormalization: [],
+      layers.AveragePooling1D: [],
+      layers.AveragePooling2D: [],
+      layers.AveragePooling3D: [],
+      layers.GlobalAveragePooling1D: [],
+      layers.GlobalAveragePooling2D: [],
+      layers.GlobalAveragePooling3D: [],
+      layers.GlobalMaxPooling1D: [],
+      layers.GlobalMaxPooling2D: [],
+      layers.GlobalMaxPooling3D: [],
+      layers.MaxPooling1D: [],
+      layers.MaxPooling2D: [],
+      layers.MaxPooling3D: [],
   }
 
   _RNN_CELLS_WEIGHTS_MAP = {
-      layers.recurrent.GRUCell: ['kernel', 'recurrent_kernel'],
-      layers.recurrent.LSTMCell: ['kernel', 'recurrent_kernel'],
-      layers.recurrent.PeepholeLSTMCell: ['kernel', 'recurrent_kernel'],
-      layers.recurrent.SimpleRNNCell: ['kernel', 'recurrent_kernel'],
+      # NOTE: RNN cells are added via compat.v1 and compat.v2 to support legacy
+      # TensorFlow 2.X behavior where the v2 RNN uses the v1 RNNCell instead of
+      # the v2 RNNCell.
+      tf.compat.v1.keras.layers.GRUCell: ['kernel', 'recurrent_kernel'],
+      tf.compat.v2.keras.layers.GRUCell: ['kernel', 'recurrent_kernel'],
+      tf.compat.v1.keras.layers.LSTMCell: ['kernel', 'recurrent_kernel'],
+      tf.compat.v2.keras.layers.LSTMCell: ['kernel', 'recurrent_kernel'],
+      tf.compat.v1.keras.experimental.PeepholeLSTMCell: [
+          'kernel', 'recurrent_kernel'
+      ],
+      tf.compat.v2.keras.experimental.PeepholeLSTMCell: [
+          'kernel', 'recurrent_kernel'
+      ],
+      tf.compat.v1.keras.layers.SimpleRNNCell: ['kernel', 'recurrent_kernel'],
+      tf.compat.v2.keras.layers.SimpleRNNCell: ['kernel', 'recurrent_kernel'],
   }
 
   _RNN_LAYERS = {
-      layers.recurrent.GRU,
-      layers.recurrent.LSTM,
-      layers.recurrent.RNN,
-      layers.recurrent.SimpleRNN,
+      layers.GRU,
+      layers.LSTM,
+      layers.RNN,
+      layers.SimpleRNN,
   }
 
   _RNN_CELLS_STR = ', '.join(str(_RNN_CELLS_WEIGHTS_MAP.keys()))
@@ -346,7 +354,7 @@ class ClusteringRegistry(object):
 
   @staticmethod
   def _get_rnn_cells(rnn_layer):
-    if isinstance(rnn_layer.cell, layers.recurrent.StackedRNNCells):
+    if isinstance(rnn_layer.cell, layers.StackedRNNCells):
       return rnn_layer.cell.cells
     return [rnn_layer.cell]
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
@@ -18,14 +18,15 @@ import numpy as np
 import tensorflow as tf
 
 from absl.testing import parameterized
-from tensorflow.keras import backend as K
 
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
 
 keras = tf.keras
-errors_impl = tf.errors
+k = keras.backend
 layers = keras.layers
+
+errors_impl = tf.errors
 test = tf.test
 
 ClusterRegistry = clustering_registry.ClusteringRegistry
@@ -39,7 +40,7 @@ class ClusteringAlgorithmTest(parameterized.TestCase):
     pulling_indices_np = np.array(pulling_indices)
     res_tf = ca.get_clustered_weight(pulling_indices_np)
 
-    res_np = K.batch_get_value([res_tf])[0]
+    res_np = k.batch_get_value([res_tf])[0]
     res_np_list = res_np.tolist()
 
     self.assertSequenceEqual(res_np_list, expected_output)
@@ -210,8 +211,8 @@ class ClusterRegistryTest(test.TestCase):
 
     def call(self, inputs, states):
       prev_output = states[0]
-      h = K.dot(inputs, self.kernel)
-      output = h + K.dot(prev_output, self.recurrent_kernel)
+      h = k.dot(inputs, self.kernel)
+      output = h + k.dot(prev_output, self.recurrent_kernel)
       return output, [output]
 
   class MinimalRNNCellClusterable(MinimalRNNCell,

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
@@ -15,21 +15,19 @@
 """Tests for keras clustering registry API."""
 
 import numpy as np
+import tensorflow as tf
+
+from absl.testing import parameterized
+from tensorflow.keras import backend as K
 
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
-
-import tensorflow.compat.v1 as tf
-import tensorflow.compat.v1.keras.backend as K
-
-from absl.testing import parameterized
 
 keras = tf.keras
 errors_impl = tf.errors
 layers = keras.layers
 test = tf.test
 
-layers = keras.layers
 ClusterRegistry = clustering_registry.ClusteringRegistry
 ClusteringLookupRegistry = clustering_registry.ClusteringLookupRegistry
 


### PR DESCRIPTION
This PR aims to remove private TF and Keras dependencies from the clustering API while maintaining compatibility with both TF 1.X and TF 2.0.