### PR TITLE
Fix link to general support matrix anchor

### DIFF
--- a/tensorflow_model_optimization/g3doc/guide/quantization/training.md
+++ b/tensorflow_model_optimization/g3doc/guide/quantization/training.md
@@ -30,7 +30,7 @@ such as the [EdgeTPU](https://coral.ai/docs/edgetpu/benchmarks/) and NNAPI.
 
 The technique is used in production in speech, vision, text, and translate use
 cases. The code currently supports a
-[subset of these models](#general_support_matrix).
+[subset of these models](#general-support-matrix).
 
 ### Experiment with quantization and associated hardware
 


### PR DESCRIPTION
Fixes broken link added in 9b593b23c051406d2de72abbd31f42105967d4a0. The anchor link should be `general-support-matrix`.