### PR TITLE
Use tf.keras.layers in LSTM pruning example.

### DIFF
--- a/tensorflow_model_optimization/python/examples/sparsity/keras/imdb/imdb_lstm.py
+++ b/tensorflow_model_optimization/python/examples/sparsity/keras/imdb/imdb_lstm.py
@@ -22,9 +22,9 @@ from __future__ import print_function
 # import g3
 import numpy as np
 
-from tensorflow.python import keras
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.preprocessing import sequence
+import tensorflow.keras as keras
+import tensorflow.keras.backend as K
+import tensorflow.keras.preprocessing.sequence as sequence
 from tensorflow_model_optimization.python.core.sparsity.keras import prune
 from tensorflow_model_optimization.python.core.sparsity.keras import pruning_callbacks
 from tensorflow_model_optimization.python.core.sparsity.keras import pruning_schedule


### PR DESCRIPTION
tensorflow.python.keras.layers.LSTM() is not registered as prunableLayer,
change LSTM_example, using registerd tensorflow.keras.layers.LSTM()

version:
TF_MOT: tf-model-optimization-nightly-0.3.0.dev20200601
TF: 2.3.0-dev20200601