### PR TITLE
Added kmeans++ initialization to clustering API

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_config.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_config.py
@@ -29,7 +29,9 @@ class CentroidInitialization(str, enum.Enum):
        axis is evenly spaced into as many regions as many clusters we want to
        have. After this the corresponding X values are obtained and used to
        initialize the clusters centroids.
+  * `KMEANS_PLUS_PLUS`: cluster centroids using the kmeans++ algorithm
   """
   LINEAR = "LINEAR"
   RANDOM = "RANDOM"
   DENSITY_BASED = "DENSITY_BASED"
+  KMEANS_PLUS_PLUS = "KMEANS_PLUS_PLUS"

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
@@ -17,12 +17,11 @@
 import abc
 import six
 import tensorflow as tf
-
+from tensorflow.python.ops import clustering_ops
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
 
 k = tf.keras.backend
 CentroidInitialization = cluster_config.CentroidInitialization
-
 @six.add_metaclass(abc.ABCMeta)
 class AbstractCentroidsInitialisation:
   """
@@ -53,6 +52,20 @@ class LinearCentroidsInitialisation(AbstractCentroidsInitialisation):
                                     self.number_of_clusters)
     return cluster_centroids
 
+class KmeansPlusPlusCentroidsInitialisation(AbstractCentroidsInitialisation):
+  """
+  Cluster centroids based on kmeans++ algorithm
+  """
+  def get_cluster_centroids(self):
+
+    weights = tf.reshape(self.weights, [-1, 1])
+
+    cluster_centroids = clustering_ops.kmeans_plus_plus_initialization(weights,
+                                                                       self.number_of_clusters,
+                                                                       seed=9,
+                                                                       num_retries_per_sample=-1)
+
+    return cluster_centroids
 
 class RandomCentroidsInitialisation(AbstractCentroidsInitialisation):
   """
@@ -192,7 +205,9 @@ class CentroidsInitializerFactory:
       CentroidInitialization.LINEAR : LinearCentroidsInitialisation,
       CentroidInitialization.RANDOM : RandomCentroidsInitialisation,
       CentroidInitialization.DENSITY_BASED :
-          DensityBasedCentroidsInitialisation
+          DensityBasedCentroidsInitialisation,
+      CentroidInitialization.KMEANS_PLUS_PLUS :
+          KmeansPlusPlusCentroidsInitialisation,
   }
 
   @classmethod

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
@@ -40,6 +40,7 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
       (CentroidInitialization.LINEAR),
       (CentroidInitialization.RANDOM),
       (CentroidInitialization.DENSITY_BASED),
+      (CentroidInitialization.KMEANS_PLUS_PLUS),
   )
   def testExistingInitsAreSupported(self, init_type):
     """
@@ -63,6 +64,10 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
           CentroidInitialization.DENSITY_BASED,
           clustering_centroids.DensityBasedCentroidsInitialisation
       ),
+      (
+          CentroidInitialization.KMEANS_PLUS_PLUS,
+          clustering_centroids.KmeansPlusPlusCentroidsInitialisation
+       ),
   )
   def testReturnsMethodForExistingInit(self, init_type, method):
     """
@@ -177,6 +182,30 @@ class ClusteringCentroidsTest(test.TestCase, parameterized.TestCase):
     calc_centroids = K.batch_get_value([dbci.get_cluster_centroids()])[0]
     self.assertSequenceAlmostEqual(centroids, calc_centroids, places=4)
 
+  @parameterized.parameters(
+    (
+            [0, 1, 2, 3, 3.1, 3.2, 3.3, 3.4, 3.5],
+            5,
+            [3.1, 0., 2., 1., 3.4]
+    ),
+    (
+            [0, 1, 2, 3, 3.1, 3.2, 3.3, 3.4, 3.5],
+            3,
+            [3.1, 0., 2.]
+    ),
+    (
+            [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.],
+            3,
+            [6., 1., 8.]
+    )
+  )
+  def testKmeanPlusPlusValues(self, weights, number_of_clusters, centroids):
+    kmci = clustering_centroids.KmeansPlusPlusCentroidsInitialisation(
+        weights,
+        number_of_clusters
+    )
+    calc_centroids = K.batch_get_value([kmci.get_cluster_centroids()])[0]
+    self.assertSequenceAlmostEqual(centroids, calc_centroids, places=4)
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Added Kmeans++ centroid initialization to the clustering API as an alternative configurable initialization method to density-based, linear and random.
Allowing the heuristic to determine the number of retries (num_retries_per_sample=-1) and a seed of 9 to match closely with the default scikit-learn kmeans++ implementation.

**Experimental results:**
| Model | Initialization | # of clusters | Top-1 accuracy (%) | Configuration | Size of compressed .tflite (MB) | 
| ------------- | ------------- |  ------------- |  ------------- | ------------- |------------- |
| MobileNetV2  |  Linear | 32 |  69.33  |  Full model (except DepthwiseConv2D layers) | 2.60 Mb|
| MobileNetV2  |  kmeans++ | 32 |  71.462%  |  Full model (except DepthwiseConv2D layers) | 3.13 Mb|
| MobileNetV2  |  Linear | 256,256,32   |  72.31%  |  Selective, last 3 Conv2D layers | 7.00 Mb|
| MobileNetV2  |  kmeans++ | 256,256,32 |  72.29% | Selective, last 3 Conv2D layers  | 7.14 Mb |
| MobileNetV1  |  Linear | 64 | 66.07%  |  Full model (except DepthwiseConv2D layers) | 2.98 Mb|
| MobileNetV1  |  kmeans++ | 64 |  70.53%  |  Full model (except DepthwiseConv2D layers) | 4.19 Mb|
| MobileNetV1  |  Linear | 256,256,32 | 70.62  |  Selective, last 3 Conv2D layers | 8.42 Mb|
| MobileNetV1  |  kmeans++ | 256,256,32 |   70.792% | Selective, last 3 Conv2D layers  | 8.91 Mb |
| DS-CNN  | Linear | 32 |  94.7% | Full model  | 0.35 Mb |
| DS-CNN  | kmeans++ | 32 |   94.7% | Full model  | 0.3 Mb |

MobileNet-V2 Linear vs. Kmeans++ convergence comparison
![mbv2](https://user-images.githubusercontent.com/44364573/87938792-ff8fc380-ca8e-11ea-97dc-2e21fdbbec35.png)


