### PR TITLE
Add clustering overview document and Jupyter notebooks to _book.yaml

### DIFF
--- a/tensorflow_model_optimization/g3doc/_book.yaml
+++ b/tensorflow_model_optimization/g3doc/_book.yaml
@@ -42,6 +42,14 @@ upper_tabs:
       - title: Post-training quantization
         path: /model_optimization/guide/quantization/post_training
 
+      - heading: Weight clustering
+      - title: Overview
+        path: /model_optimization/guide/clustering
+      - title: Weight clustering example
+        path: /model_optimization/guide/clustering/clustering_example
+      - title: Weight clustering comprehensive guide
+        path: /model_optimization/guide/clustering/clustering_comprehensive_guide
+
     - name: API
       skip_translation: true
       contents:


### PR DESCRIPTION
This PR adds the relevant weight clustering documentation to `_book.yaml` in order to make them visible on the TFMOT site.

Note: This depends on https://github.com/tensorflow/model-optimization/pull/330