### PR TITLE
Enable differentiable training and update cluster indices

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -48,7 +48,7 @@ def cluster_scope():
   """
   return CustomObjectScope(
       {
-          'ClusterWeights' : cluster_wrapper.ClusterWeights
+          'ClusterWeights': cluster_wrapper.ClusterWeights
       }
   )
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -27,6 +27,7 @@ keras = tf.keras
 k = keras.backend
 Layer = keras.layers.Layer
 Wrapper = keras.layers.Wrapper
+CentroidInitialization = cluster_config.CentroidInitialization
 
 
 class ClusterWeights(Wrapper):
@@ -105,7 +106,7 @@ class ClusterWeights(Wrapper):
     self.number_of_clusters = number_of_clusters
 
     # Stores the pairs of weight names and references to their tensors
-    self.clustered_vars = []
+    self.ori_weights_vars_tf = {}
 
     # Stores references to class instances that implement different clustering
     # behaviour for different shapes of objects
@@ -227,24 +228,33 @@ class ClusterWeights(Wrapper):
       )
 
       # We store these pairs to easily update this variables later on
-      self.clustered_vars.append((weight_name, weight))
+      self.ori_weights_vars_tf[weight_name] = self.add_weight(
+          'ori_weights_vars_tf',
+          shape=weight.shape,
+          dtype=weight.dtype,
+          trainable=True,
+          initializer=initializers.Constant(
+              value=k.batch_get_value([weight])[0]
+          )
+      )
 
     # We use currying here to get an updater which can be triggered at any time
     # in future and it would return the latest version of clustered weights
     def get_updater(for_weight_name):
       def fn():
-        return self.clustering_impl[for_weight_name].get_clustered_weight(
-            self.pulling_indices_tf[for_weight_name]
-        )
+        # Get the clustered weights
+        pulling_indices = self.pulling_indices_tf[for_weight_name]
+        clustered_weights = self.clustering_impl[for_weight_name].\
+            get_clustered_weight(pulling_indices)
+        return clustered_weights
 
       return fn
 
     # This will allow us to restore the order of weights later
     # This loop stores pairs of weight names and how to restore them
-
     for ct, weight in enumerate(self.layer.weights):
       name = self._weight_name(weight.name)
-      full_name = self.layer.name + "/" + name
+      full_name = '{}{}{}'.format(self.layer.name, '/', name)
       if ct in self.gone_variables:
         # Again, not sure if this is needed
         weight_name = clusterable_weights_to_variables[name]
@@ -253,14 +263,26 @@ class ClusterWeights(Wrapper):
         self.restore.append((name, full_name, weight))
 
   def call(self, inputs):
+    # In the forward pass, we need to update the cluster associations manually
+    # since they are integers and not differentiable. Gradients won't flow back
+    # through tf.argmin
     # Go through all tensors and replace them with their clustered copies.
-    for weight_name, _ in self.clustered_vars:
-      setattr(
-          self.layer, weight_name,
-          self.clustering_impl[weight_name].get_clustered_weight(
-              self.pulling_indices_tf[weight_name]
-          )
-      )
+    for weight_name in self.ori_weights_vars_tf:
+      pulling_indices = self.pulling_indices_tf[weight_name]
+
+      # Update cluster associations
+      pulling_indices.assign(tf.dtypes.cast(
+          self.clustering_impl[weight_name].\
+              get_pulling_indices(self.ori_weights_vars_tf[weight_name]),
+          pulling_indices.dtype
+      ))
+
+      clustered_weights = self.clustering_impl[weight_name].\
+          get_clustered_weight_forward(pulling_indices,\
+              self.ori_weights_vars_tf[weight_name])
+
+      # Replace the weights with their clustered counterparts
+      setattr(self.layer, weight_name, clustered_weights)
 
     return self.layer.call(inputs)
 
@@ -271,7 +293,7 @@ class ClusterWeights(Wrapper):
     base_config = super(ClusterWeights, self).get_config()
     config = {
         'number_of_clusters': self.number_of_clusters,
-        'cluster_centroids_init': self.cluster_centroids_init,
+        'cluster_centroids_init': self.cluster_centroids_init
     }
     return dict(list(base_config.items()) + list(config.items()))
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
@@ -15,7 +15,6 @@
 """Tests for keras ClusterWeights wrapper API."""
 
 import itertools
-import numpy as np
 import tensorflow as tf
 
 from absl.testing import parameterized
@@ -155,9 +154,9 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
       *itertools.product(
           range(2, 16, 4),
           (
-            CentroidInitialization.LINEAR,
-            CentroidInitialization.RANDOM,
-            CentroidInitialization.DENSITY_BASED
+              CentroidInitialization.LINEAR,
+              CentroidInitialization.RANDOM,
+              CentroidInitialization.DENSITY_BASED
           )
       )
   )
@@ -193,6 +192,68 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
     # Check that we keep names for weights/bias
     self.assertEqual(stripped_model.layers[0].weights[0].name, weights_name)
     self.assertEqual(stripped_model.layers[0].weights[1].name, bias_name)
+
+  def testClusterReassociation(self):
+    """
+    Verifies that the association of weights to cluster centroids are updated
+    every iteration.
+    """
+
+    # Create a dummy layer for this test
+    input_shape = (1, 2,)
+    l = cluster_wrapper.ClusterWeights(
+        keras.layers.Dense(8, input_shape=input_shape),
+        number_of_clusters=2,
+        cluster_centroids_init=CentroidInitialization.LINEAR
+    )
+    # Build a layer with the given shape
+    l.build(input_shape)
+
+    # Get name of the clusterable weights
+    clusterable_weights = l.layer.get_clusterable_weights()
+    self.assertEqual(len(clusterable_weights), 1)
+    weights_name = clusterable_weights[0][0]
+    self.assertEqual(weights_name, 'kernel')
+    # Get cluster centroids
+    centroids = l.cluster_centroids_tf[weights_name]
+
+    # Calculate some statistics of the weights to set the centroids later on
+    mean_weight = tf.reduce_mean(l.layer.kernel)
+    min_weight = tf.reduce_min(l.layer.kernel)
+    max_weight = tf.reduce_max(l.layer.kernel)
+    max_dist = max_weight - min_weight
+
+    def assert_all_weights_associated(weights, centroid_index):
+      """Helper function to make sure that all weights are associated with one
+      centroid."""
+      all_associated = tf.reduce_all(
+          tf.equal(
+              weights,
+              tf.constant(centroids[centroid_index], shape=weights.shape)
+          )
+      )
+      self.assertTrue(all_associated)
+
+    # Set centroids so that all weights should be re-associated with centroid 0
+    centroids[0].assign(mean_weight)
+    centroids[1].assign(mean_weight + 2.0 * max_dist)
+
+    # Update associations of weights to centroids
+    l.call(tf.ones(shape=input_shape))
+
+    # Weights should now be all clustered with the centroid 0
+    assert_all_weights_associated(l.layer.kernel, centroid_index=0)
+
+    # Set centroids so that all weights should be re-associated with centroid 1
+    centroids[0].assign(mean_weight - 2.0 * max_dist)
+    centroids[1].assign(mean_weight)
+
+    # Update associations of weights to centroids
+    l.call(tf.ones(shape=input_shape))
+
+    # Weights should now be all clustered with the centroid 1
+    assert_all_weights_associated(l.layer.kernel, centroid_index=1)
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
**Motivation**:

In the current clustering implementation, the original weights of the clustered layers and the cluster indices are not updated during each training step. Tho the training process alters the values of the cluster centroids, due to the changes in other non-clustered layers, which are reflected in the gradients during training, the non-updated original weights will not always match the constantly updated cluster centroids and will create problems during training. In order to fix this issue, we want to update the original weights after the backpropagation. After that, using the updated centroids, the indices should be re-generated in the next training step. In this PR, changes are made and the unit tests for them are created too.

**Details of the implementation**:
As shown in the figure below, in the forward pass of our current clustering implementation, first, it uses density-based or linear methods to initialize the centroids (c) for the weights of each layer. Then, the original set of weights (W) are grouped into several clusters using the centroid values. Afterward, the association between the weights and the centroids is calculated based on c and W as indices. Finally, for a single cluster, the centroid value will be shared among all the weights and used in the forward pass instead of the original weights.
![image2020-4-28_20-53-11](https://user-images.githubusercontent.com/36263048/90791267-e59d0700-e300-11ea-96a0-aa34432bde87.png)
In the current backpropagation, the clustered weights will get the gradients from the layer being wrapped. These gradients will be fed into the node gather. Then, the gather node groups all the gradients by indices and accumulates them as the gradients of the centroids. However, due to the non-differentiable node `tf.math.argmin`, no gradients will be calculated for original weights W by automatic differentiation in TensorFlow.

1) how to update the original weights?
A small modification (gradient approximations using the straight-through estimator [1]) of the training graph is used to override the gradient during backpropagation like this:
`clustered_weights = tf.gather(cluster_centroids, indices)*tf.sign(original_weights + 1e+6)`
In the forward pass, the `multiply` in the graph does not change the graph (`tf.sign` gives out identity matrix) but in the backpropagation, the multiply is changed into add and the `tf.sign` is changed into identity via `tf.custom_gradient`. Essentially, the graph becomes:
`clustered_weights = tf.gather(cluster_centroids, indices)+tf.identity(original_weights + 1e+6)`
In this way, original weights can be updated by the automatic differentiation in TensorFlow.
2) how to update cluster indices?
Indices are not differentiable themselves and they are calculated only in the forward pass during training. Therefore, they are updated using `tf.assign` specifically in the forward pass in the `call` function. This will lead to some extra change for using `tf.distribute`, which has not been covered in this PR.

**Result table**:
As shown in the table below, the changes in this PR significantly improve the accuracy when the number of clusters is small and give limited benefit for other configurations.

| Model | Number of clusters | tfmot | tfmot+this PR | delta |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Mobilenet_v1 | full model (all 64) | 65.03% | 66.65% | 1.62% |
|                        |                              | 3.11 MB | 3.06 MB | -0.05 MB |
|                        | selective clustering (32 32 32) | 49.72% | 68% | 18.28% |
|                        |                                                  | 7.17 MB | 6.99 MB | -0.18 MB | 
|                        | selective clustering (256 256 32) | 70.16% | 69.32% | -0.84% |
|                        |                                                     | 8.32 MB | 7.68 MB | -0.64 MB |                            
| Mobilenet_v2 | full model (all 32) | 68.26% | 69.09% | 0.83% |
|                        |                              | 2.65 MB | 2.64 MB | -0.01 MB |
|                        | selective clustering (8 8 8) | 35.05%| 67.28%| 32.23%|
|                        |                              | 6.25 MB | 6.23 MB | -0.02 MB |
|                        | selective clustering (16 16 16) | 67.10% | 70.94% | 3.84% |
|                        |                              | 6.59 MB | 6.42 MB | -0.17 MB |
|                        | selective clustering (256 256 32) | 72.3% | 72.30% | 0|
|                        |                              | 7.31 MB | 7.18 MB | -0.13 MB |
| DS-CNN-L | full model (all 32) | 94.77% | 94.86% | 0.09% |
|                        |                              | 0.33 MB | 0.33 MB | 0 MB |
|                   | full model (all 8)   | 73.51% | 86.83% | 13.32% |
|                        |                              | 0.19 MB | 0.19 MB | 0 MB |

Reference:
[1] Y. Bengio, N. Leonard, and A. Courville.  Estimating or propagating gradients through stochastic neurons for conditional computation. *arXiv preprint arXiv:1308.3432, 2013.*