### PR TITLE
Fix _weight_name() for layers with multiple '/'

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/graph_transformations/model_transformer.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/graph_transformations/model_transformer.py
@@ -424,7 +424,7 @@ class ModelTransformer(object):
     Returns:
       Extracted weight name.
     """
-    return name.split('/')[-1]
+    return name.partition('/')[2]
 
   def _get_keras_layer_weights(self, keras_layer):
     """Returns a map of weight name, weight matrix. Keeps keras ordering."""


### PR DESCRIPTION
The _weight_name() method fails to recognise models with weights that have multiple weights with parts, such as 'quantize_annotate_3/conv1d_26/kernel:0' and 'quantize_annotate_3/conv1d_27/kernel:0'. In such case, since the names are inserted into a dict, the kernel:0 part for conv1d_26 will clash with kernel:0 for conv1d_27 and instead of having 2 weight sets, we will have only one. By doing the partitioning on '/' and taking the part after the first '/', such situations can be avoided while still removing the layer name from TF variable name.