### PR TITLE
Fix to add clustering_callbacks.py to the pip package

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,14 @@ Keras pruning API:
 * Tested against TensorFlow 1.14.0, 2.0.0, and nightly, and Python 3.
 
 
+# TensorFlow Model Optimization next release TBD
+
+Keras clustering API:
+
+* Added *ClusteringSummaries* to create additional output for the clustering
+progress for TensorBoard.
+* Tested against TensorFlow 1.14.0, 2.0.0, and nightly, and Python 3.
+
 # TensorFlow Model Optimization 0.5.0
 
 TFMOT 0.5.0 adds some additional features for Quantization Aware Training. QAT

--- a/tensorflow_model_optimization/python/core/api/clustering/keras/__init__.py
+++ b/tensorflow_model_optimization/python/core/api/clustering/keras/__init__.py
@@ -21,4 +21,5 @@ from tensorflow_model_optimization.python.core.clustering.keras.cluster import c
 from tensorflow_model_optimization.python.core.clustering.keras.cluster import strip_clustering
 
 from tensorflow_model_optimization.python.core.clustering.keras.cluster_config import CentroidInitialization
+from tensorflow_model_optimization.python.core.clustering.keras.clustering_callbacks import ClusteringSummaries
 # pylint: enable=g-bad-import-order

--- a/tensorflow_model_optimization/python/core/clustering/keras/BUILD
+++ b/tensorflow_model_optimization/python/core/clustering/keras/BUILD
@@ -12,6 +12,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":cluster",
+        ":clustering_callbacks",
         "//tensorflow_model_optimization/python/core/clustering/keras/experimental",
     ],
 )


### PR DESCRIPTION
This is a small fix to add a dependency on `clustering_callbacks.py` so that the file is added to the pip package.