### PR TITLE
Revert "Small tidy up: Removed unused leftover variables."

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -326,11 +326,11 @@ class ClusterWeights(Wrapper):
 
   @property
   def trainable_weights(self):
-    return self.layer.trainable_weights
+    return self.layer.trainable_weights + self._trainable_weights
 
   @property
   def non_trainable_weights(self):
-    return self.layer.non_trainable_weights
+    return self.layer.non_trainable_weights + self._non_trainable_weights
 
   @property
   def updates(self):


### PR DESCRIPTION
This reverts commit 7b7fe538640c484388dbce4390d126d57c070f91 (see PR #557 for discussion) that causes problems and was accidentally merged.

