### PR TITLE
Add check before setting bias of conv_weights in  SeparableConvQuantize

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/default_8bit/default_8bit_transforms.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/default_8bit/default_8bit_transforms.py
@@ -482,7 +482,8 @@ class SeparableConvQuantize(transforms.Transform):
     )
     conv_weights = collections.OrderedDict()
     conv_weights['kernel:0'] = sepconv_weights[1]
-    conv_weights['bias:0'] = sepconv_weights[2]
+    if sepconv_layer['config']['use_bias']:
+      conv_weights['bias:0'] = sepconv_weights[2]
     conv_layer_config = keras.layers.serialize(conv_layer)
     conv_layer_config['name'] = conv_layer.name
     # Needed to ensure these new layers are considered for quantization.


### PR DESCRIPTION
Not to copy the weights if bias is not used in the SeperableConv2D layer