### PR TITLE
[clustering] Fixed strip_clustering when using kernel_regularizer

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -15,6 +15,7 @@
 """Clustering API functions for Keras models."""
 
 from tensorflow import keras
+from tensorflow.keras import initializers
 
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_wrapper
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
@@ -313,13 +314,25 @@ def strip_clustering(model):
           # If the variable was removed because it was clustered, we restore it
           # by using updater we created earlier
           new_weight_value = k.batch_get_value([weight()])[0]
+          setattr(layer.layer, name, k.constant(new_weight_value,
+                    dtype=new_weight_value.dtype,
+                    shape=new_weight_value.shape,
+                    name=weight_name))
         else:
           # If the value was not clustered(e.g. bias), we still store a valid
           # reference to the tensor. We use this reference to get the value
           new_weight_value = k.batch_get_value([weight])[0]
-        setattr(layer.layer,
-                name,
-                k.variable(new_weight_value, name=weight_name))
+        layer.layer.add_weight(
+            weight_name,
+            shape=new_weight_value.shape,
+            dtype=new_weight_value.dtype,
+            trainable=True,
+            initializer=initializers.Constant(
+                value=new_weight_value
+            )
+        )
+      if layer.regularizers:
+        setattr(layer.layer, 'kernel_regularizer', layer.regularizers)
       # When all weights are filled with the values, just return the underlying
       # layer since it is now fully autonomous from its wrapper
       return layer.layer

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -199,6 +199,25 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
     self.assertLessEqual(
         len(unique_weights_after_tuning), self.params["number_of_clusters"])
 
+  @keras_parameterized.run_all_keras_modes
+  def testStripClusteringSequentialModelWithRegularizer(self):
+      """
+      Verifies that stripping the clustering wrappers from a sequential model
+      produces the expected config.
+      """
+      original_model = keras.Sequential([
+          layers.Dense(5, input_shape=(5,)),
+          layers.Dense(5, kernel_regularizer=tf.keras.regularizers.L1(0.01)),
+      ])
+
+      def clusters_check(stripped_model):
+          # dense layer
+          weights_as_list = stripped_model.get_weights()[0].reshape(-1, ).tolist()
+          unique_weights = set(weights_as_list)
+          self.assertLessEqual(len(unique_weights), self.params["number_of_clusters"])
+
+      self.end_to_end_testing(original_model, clusters_check)
+
   @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
   def testEndToEndSequential(self):
     """Test End to End clustering - sequential model."""

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -126,6 +126,7 @@ class ClusterWeights(Wrapper):
     # A list for restoring the original order of weights later on, see the
     # comments in the code for usage explanations
     self.restore = []
+    self.regularizers = None
 
     # setattr will remove the original weights from layer.weights array. We need
     # to memorise the original state of the array since saving the model relies
@@ -286,6 +287,9 @@ class ClusterWeights(Wrapper):
         self.restore.append((name, full_name, get_updater(weight_name)))
       else:
         self.restore.append((name, full_name, weight))
+
+    if hasattr(self.layer, 'kernel_regularizer') and self.layer.kernel_regularizer != None:
+      self.regularizers = self.layer.kernel_regularizer
 
   def call(self, inputs):
     # In the forward pass, we need to update the cluster associations manually


### PR DESCRIPTION
Added kernel_regularizer to clustering API
Fixed issue where the original weights were being maintained within the graph after clustering & stripping.
Added unit tests for keras kernel_regularizer