### PR TITLE
fix quantize_annotate_layer() got an unexpected keyword argument 'inp…

### DIFF
--- a/tensorflow_model_optimization/python/examples/quantization/keras/mnist_cnn.py
+++ b/tensorflow_model_optimization/python/examples/quantization/keras/mnist_cnn.py
@@ -59,8 +59,7 @@ l = tf.keras.layers
 
 model = tf.keras.Sequential([
     quantize.quantize_annotate_layer(
-        l.Conv2D(32, 5, padding='same', activation='relu'),
-        input_shape=input_shape),
+        l.Conv2D(32, 5, padding='same', activation='relu', input_shape=input_shape)),
     l.MaxPooling2D((2, 2), (2, 2), padding='same'),
     quantize.quantize_annotate_layer(
         l.Conv2D(64, 5, padding='same', activation='relu')),


### PR DESCRIPTION
Run `mnist_cnn.py`，got Error：
···
x_train shape: (60000, 28, 28, 1)
60000 train samples
10000 test samples
Traceback (most recent call last):
  File "mnist_cnn.py", line 63, in <module>
    input_shape=input_shape),
TypeError: quantize_annotate_layer() got an unexpected keyword argument 'input_shape'
···