### PR TITLE
[Clustering] Average Gradient Aggregation

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/BUILD
+++ b/tensorflow_model_optimization/python/core/clustering/keras/BUILD
@@ -82,6 +82,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
     ],
 )
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_config.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_config.py
@@ -31,7 +31,19 @@ class CentroidInitialization(str, enum.Enum):
        initialize the clusters centroids.
   * `KMEANS_PLUS_PLUS`: cluster centroids using the kmeans++ algorithm
   """
-  LINEAR = "LINEAR"
-  RANDOM = "RANDOM"
-  DENSITY_BASED = "DENSITY_BASED"
-  KMEANS_PLUS_PLUS = "KMEANS_PLUS_PLUS"
+  LINEAR = "CentroidInitialization.LINEAR"
+  RANDOM = "CentroidInitialization.RANDOM"
+  DENSITY_BASED = "CentroidInitialization.DENSITY_BASED"
+  KMEANS_PLUS_PLUS = "CentroidInitialization.KMEANS_PLUS_PLUS"
+
+
+class GradientAggregation(str, enum.Enum):
+  """Specifies how the cluster gradient should be aggregated.
+
+  * `SUM`: The gradient of each cluster centroid is the sum of their
+      respective child’s weight gradient.
+  * `AVG`: The gradient of each cluster centroid is the averaged sum of
+      their respective child’s weight gradient.
+  """
+  SUM = "GradientAggregation.SUM"
+  AVG = "GradientAggregation.AVG"

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_distributed_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_distributed_test.py
@@ -43,7 +43,6 @@ class ClusterDistributedTest(tf.test.TestCase, parameterized.TestCase):
         "cluster_centroids_init": CentroidInitialization.LINEAR
     }
 
-
   @parameterized.parameters(_distribution_strategies())
   def testClusterSimpleDenseModel(self, distribution):
     """End-to-end test."""
@@ -64,7 +63,7 @@ class ClusterDistributedTest(tf.test.TestCase, parameterized.TestCase):
     model.predict(np.random.rand(20, 10))
 
     stripped_model = cluster.strip_clustering(model)
-    weights_as_list = stripped_model.get_weights()[0].reshape(-1,).tolist()
+    weights_as_list = stripped_model.layers[0].kernel.numpy().reshape(-1,).tolist()
     unique_weights = set(weights_as_list)
     self.assertLessEqual(len(unique_weights), self.params["number_of_clusters"])
 
@@ -87,7 +86,7 @@ class ClusterDistributedTest(tf.test.TestCase, parameterized.TestCase):
       self.assertEqual(len(clusterable_weights), 1)
       weights_name = clusterable_weights[0][0]
       self.assertEqual(weights_name, 'kernel')
-      centroids1 = l.cluster_centroids_tf[weights_name]
+      centroids1 = l.cluster_centroids[weights_name]
 
       mean_weight = tf.reduce_mean(l.layer.kernel)
       min_weight = tf.reduce_min(l.layer.kernel)
@@ -119,18 +118,18 @@ class ClusterDistributedTest(tf.test.TestCase, parameterized.TestCase):
           centroids1, update_fn, args=(initial_val,))
       l.call(tf.ones(shape=input_shape))
 
-      clst_indices = l.pulling_indices_tf[weights_name]
+      clst_indices = l.pulling_indices[weights_name]
       per_replica = distribution.experimental_local_results(clst_indices)
       assert_all_cluster_indices(per_replica, 0)
 
       second_val = tf.Variable([mean_weight - 2.0 * max_dist, mean_weight], \
         aggregation=tf.VariableAggregation.MEAN)
-      centroids2 = l.cluster_centroids_tf[weights_name]
+      centroids2 = l.cluster_centroids[weights_name]
       centroids2 = distribution.extended.update(
           centroids2, update_fn, args=(second_val,))
       l.call(tf.ones(shape=input_shape))
 
-      clst_indices = l.pulling_indices_tf[weights_name]
+      clst_indices = l.pulling_indices[weights_name]
       per_replica = distribution.experimental_local_results(clst_indices)
       assert_all_cluster_indices(per_replica, 1)
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -174,7 +174,7 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
         original_model, **clustering_params)
 
     stripped_model_before_tuning = cluster.strip_clustering(clustered_model)
-    weights_before_tuning = stripped_model_before_tuning.get_weights()[0]
+    weights_before_tuning = stripped_model_before_tuning.layers[0].kernel
     non_zero_weight_indices_before_tuning = np.nonzero(weights_before_tuning)
 
     clustered_model.compile(
@@ -185,9 +185,9 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
     clustered_model.fit(x=self.dataset_generator2(), steps_per_epoch=1)
 
     stripped_model_after_tuning = cluster.strip_clustering(clustered_model)
-    weights_after_tuning = stripped_model_after_tuning.get_weights()[0]
+    weights_after_tuning = stripped_model_after_tuning.layers[0].kernel
     non_zero_weight_indices_after_tuning = np.nonzero(weights_after_tuning)
-    weights_as_list_after_tuning = weights_after_tuning.reshape(-1,).tolist()
+    weights_as_list_after_tuning = weights_after_tuning.numpy().reshape(-1,).tolist()
     unique_weights_after_tuning = set(weights_as_list_after_tuning)
 
     # Check that the null weights stayed the same before and after tuning.
@@ -298,6 +298,54 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
           len(unique_weights), self.params["number_of_clusters"])
 
     self.end_to_end_testing(original_model, clusters_check)
+
+  @keras_parameterized.run_all_keras_modes
+  def testWeightsAreLearningDuringClustering(self):
+    """Verifies that training a clustered model does update
+    original_weights, clustered_centroids and bias."""
+    original_model = keras.Sequential([
+      layers.Dense(5, input_shape=(5,))
+    ])
+
+    clustered_model = cluster.cluster_weights(original_model, **self.params)
+
+    clustered_model.compile(
+      loss=keras.losses.categorical_crossentropy,
+      optimizer="adam",
+      metrics=["accuracy"],
+    )
+
+    class CheckWeightsCallback(keras.callbacks.Callback):
+      def on_train_batch_begin(self, batch, logs=None):
+        # Save weights before batch
+        self.original_weight_kernel = (
+          self.model.layers[0].original_clusterable_weights['kernel'].numpy()
+        )
+        self.cluster_centroids_kernel = (
+          self.model.layers[0].cluster_centroids['kernel'].numpy()
+        )
+        self.bias = (
+          self.model.layers[0].layer.bias.numpy()
+        )
+
+      def on_train_batch_end(self, batch, logs=None):
+        # Check weights are different after batch
+        assert not np.array_equal(
+          self.original_weight_kernel,
+          self.model.layers[0].original_clusterable_weights['kernel'].numpy()
+        )
+        assert not np.array_equal(
+          self.cluster_centroids_kernel,
+          self.model.layers[0].cluster_centroids['kernel'].numpy()
+        )
+        assert not np.array_equal(
+          self.bias,
+          self.model.layers[0].layer.bias.numpy()
+        )
+
+    clustered_model.fit(x=self.dataset_generator(),
+                        steps_per_epoch=5,
+                        callbacks=[CheckWeightsCallback()])
 
 
 if __name__ == "__main__":

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper_test.py
@@ -194,7 +194,7 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
     weights_name = clusterable_weights[0][0]
     self.assertEqual(weights_name, 'kernel')
     # Get cluster centroids
-    centroids = l.cluster_centroids_tf[weights_name]
+    centroids = l.cluster_centroids[weights_name]
 
     # Calculate some statistics of the weights to set the centroids later on
     mean_weight = tf.reduce_mean(l.layer.kernel)
@@ -244,6 +244,8 @@ class ClusterWeightsTest(test.TestCase, parameterized.TestCase):
     # Build a layer with the given shape
     original_layer.build(input_shape)
     model = keras.Sequential([original_layer])
+    # Update cluster association at least once
+    original_layer.update_clustered_weights_associations()
 
     # Save and load the layer in a temp directory
     with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_algorithm.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_algorithm.py
@@ -18,10 +18,12 @@ import abc
 import six
 import tensorflow as tf
 
+from tensorflow_model_optimization.python.core.clustering.keras.cluster_config import GradientAggregation
+
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractClusteringAlgorithm(object):
-  """Abstrac class to implement highly efficient vectorised look-ups.
+  """Abstract class to implement highly efficient vectorised look-ups.
 
     We do not utilise looping for that purpose, instead we `smartly` reshape and
     tile arrays. The trade-off is that we are potentially using way more memory
@@ -33,7 +35,10 @@ class AbstractClusteringAlgorithm(object):
     For example, look-ups for 2D table will be different in the case of 3D.
   """
 
-  def __init__(self, clusters_centroids):
+  def __init__(self,
+               clusters_centroids,
+               cluster_gradient_aggregation=GradientAggregation.SUM,
+               ):
     """Generating clustered tensors.
 
     For generating clustered tensors we will need two things: cluster
@@ -42,8 +47,14 @@ class AbstractClusteringAlgorithm(object):
     Args:
       clusters_centroids: An array of shape (N,) that contains initial
       values of clusters centroids.
+      cluster_gradient_aggregation: An enum that specify the aggregation
+      method of the cluster gradient.
     """
+    if not isinstance(clusters_centroids, tf.Variable):
+      raise ValueError("clusters_centroids should be a tf.Variable.")
+
     self.cluster_centroids = clusters_centroids
+    self.cluster_gradient_aggregation = cluster_gradient_aggregation
 
   @abc.abstractmethod
   def get_pulling_indices(self, weight):
@@ -66,68 +77,83 @@ class AbstractClusteringAlgorithm(object):
     """
     pass
 
-  @tf.custom_gradient
-  def add_custom_gradients(self, clst_weights, weights):
-    """Adds custom gradients in the backprop stage.
+  def get_clustered_weight(self, pulling_indices, original_weight):
+    """Returns clustered weights with custom gradients.
 
-    This function overrides gradients in the backprop stage: original mul
-    becomes add, tf.sign becomes tf.identity. It is to update the original
-    weights with the gradients updates directly from the layer wrapped. We
-    assume the gradients updates on individual elements inside a cluster
-    will be different so that there is no point of mapping the gradient
-    updates back to original weight matrix using the LUT.
-
+    Take indices (pulling_indices) as input and then form a new array
+    by gathering cluster centroids based on the given pulling indices.
+    The original gradients will also be modified in two ways:
+    - By averaging the gradient of cluster_centroids based on the size of
+      each cluster.
+    - By adding an estimated gradient onto the non-differentiable
+      original weight.
     Args:
-      clst_weights: cluster weights
-      weights: weights
-    Returns:
-      custom gradient
-    """
-    override_weights = tf.sign(tf.reshape(weights, shape=(-1,)) + 1e+6)
-    z = clst_weights * override_weights
-
-    def grad(dz):
-      return dz, dz
-
-    return z, grad
-
-  def get_clustered_weight(self, pulling_indices):
-    """Returns clustered weights.
-
-    Takes an array with integer number that represent lookup indices and
-    forms a new array according to the given indices.
-
-    Args:
-      pulling_indices: an array of indices used for lookup.
-    Returns:
-      An array with the same shape as `pulling_indices`. Each array element
-      is a member of self.cluster_centroids.
-    """
-
-    return tf.reshape(
-        tf.gather(self.cluster_centroids,
-                  tf.reshape(pulling_indices, shape=(-1,))),
-        shape=pulling_indices.shape)
-
-  def get_clustered_weight_forward(self, pulling_indices, weight):
-    """Returns clustered weights with custm gradiennt.
-
-    Takes indices (pulling_indices) and original weights (weight) as inputs
-
-    and then forms a new array according to the given indices. The original
-    weights (weight) here are added to the graph since we want the backprop
-    to update their values via the new implementation using tf.custom_gradient
-
-    Args:
-      pulling_indices: an array of indices used for lookup.
-      weight: the original weights of the wrapped layer.
+      pulling_indices: a tensor of indices used for lookup of the same
+      size as original_weight.
+      original_weight: the original weights of the wrapped layer.
     Returns:
       array with the same shape as `pulling_indices`. Each array element
-      is a member of self.cluster_centroids
+      is a member of self.cluster_centroids. The backward pass is modified by
+      adding custom gradients.
     """
 
-    x = tf.reshape(self.get_clustered_weight(pulling_indices), shape=(-1,))
+    @tf.custom_gradient
+    def average_centroids_gradient_by_cluster_size(cluster_centroids, cluster_sizes):
+      def grad(d_cluster_centroids):
+        # Average the gradient based on the number of weights belonging to each cluster
+        d_cluster_centroids = tf.math.divide_no_nan(d_cluster_centroids, cluster_sizes)
+        return d_cluster_centroids, None
 
-    return tf.reshape(
-        self.add_custom_gradients(x, tf.reshape(weight, shape=(-1,))),
-        pulling_indices.shape)
+      return cluster_centroids, grad
+
+    @tf.custom_gradient
+    def add_gradient_to_original_weight(clustered_weight, original_weight):
+      """
+      This function overrides gradients in the backprop stage: the Jacobian
+      matrix of multiplication is replaced with the identity matrix, which
+      effectively changes multiplication into add in the backprop. Since
+      the gradient of tf.sign is 0, overwriting it with identity follows
+      the design of straight-through-estimator, which accepts all upstream
+      gradients and uses them to update original non-clustered weights of
+      the layer. Here, we assume the gradient updates on individual elements
+      inside a cluster will be different so that there is no point in mapping
+      the gradient updates back to original non-clustered weights using the LUT.
+      """
+      override_weights = tf.sign(original_weight + 1e+6)
+      override_clustered_weight = clustered_weight * override_weights
+
+      def grad(d_override_clustered_weight):
+        return d_override_clustered_weight, d_override_clustered_weight
+
+      return override_clustered_weight, grad
+
+    if self.cluster_gradient_aggregation == GradientAggregation.SUM:
+      cluster_centroids = self.cluster_centroids
+    elif self.cluster_gradient_aggregation == GradientAggregation.AVG:
+      # Compute the size of each cluster (number of weights belonging to each cluster)
+      cluster_sizes = tf.math.bincount(
+        arr=tf.cast(pulling_indices, dtype=tf.int32),
+        minlength=tf.size(self.cluster_centroids),
+        dtype=self.cluster_centroids.dtype,
+      )
+      # Modify the gradient of cluster_centroids to be averaged by cluster sizes
+      cluster_centroids = average_centroids_gradient_by_cluster_size(
+        self.cluster_centroids,
+        tf.stop_gradient(cluster_sizes),
+      )
+    else:
+      raise ValueError(f"self.cluster_gradient_aggregation="
+                       f"{self.cluster_gradient_aggregation} not implemented.")
+
+    # Gather the clustered weights based on cluster centroids and pulling indices
+    clustered_weight = tf.gather(cluster_centroids, pulling_indices)
+
+    # Add an estimated gradient to the original weight
+    clustered_weight = add_gradient_to_original_weight(
+      clustered_weight,
+      # Fix the bug with MirroredVariable and tf.custom_gradient:
+      # tf.identity will transform a MirroredVariable into a Variable
+      tf.identity(original_weight),
+    )
+
+    return clustered_weight

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
@@ -330,8 +330,8 @@ class ClusteringRegistry(object):
       raise ValueError('Layer ' + str(layer.__class__) + ' is not supported.')
 
     def get_clusterable_weights():
-      return [(weight, getattr(layer, weight)) for weight in
-              cls._weight_names(layer)]
+      return [(weight_name, getattr(layer, weight_name))
+              for weight_name in cls._weight_names(layer)]
 
     def get_clusterable_weights_rnn():  # pylint: disable=missing-docstring
       def get_clusterable_weights_rnn_cell(cell):

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
@@ -14,13 +14,13 @@
 # ==============================================================================
 """Tests for keras clustering registry API."""
 
-import numpy as np
 import tensorflow as tf
 
 from absl.testing import parameterized
 
 from tensorflow_model_optimization.python.core.clustering.keras import clusterable_layer
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
+from tensorflow_model_optimization.python.core.clustering.keras.cluster_config import GradientAggregation
 
 keras = tf.keras
 k = keras.backend
@@ -33,59 +33,109 @@ ClusterRegistry = clustering_registry.ClusteringRegistry
 ClusteringLookupRegistry = clustering_registry.ClusteringLookupRegistry
 
 
-class ClusteringAlgorithmTest(parameterized.TestCase):
+class ClusteringAlgorithmTest(tf.test.TestCase, parameterized.TestCase):
   """Unit tests for clustering lookup algorithms"""
 
-  def _pull_values(self, ca, pulling_indices, expected_output):
-    pulling_indices_np = np.array(pulling_indices)
-    res_tf = ca.get_clustered_weight(pulling_indices_np)
+  def _check_pull_values(self, clustering_algo, pulling_indices, expected_output):
+    pulling_indices = tf.convert_to_tensor(pulling_indices)
 
-    res_np = k.batch_get_value([res_tf])[0]
-    res_np_list = res_np.tolist()
+    clustered_weight = clustering_algo.get_clustered_weight(
+      pulling_indices, original_weight=tf.zeros(pulling_indices.shape, dtype=tf.float32)
+    )
+    self.assertAllEqual(clustered_weight, expected_output)
 
-    self.assertSequenceEqual(res_np_list, expected_output)
+  def _check_gradients_clustered_weight(
+      self,
+      clustering_algo,
+      weight,
+      pulling_indices,
+      expected_grad_centroids,
+  ):
+    pulling_indices = tf.convert_to_tensor(pulling_indices)
+    cluster_centroids = clustering_algo.cluster_centroids
 
-  def _check_gradients(self, ca, weight, pulling_indices, expected_output):
-    pulling_indices_tf = tf.convert_to_tensor(pulling_indices)
-    weight_tf = tf.convert_to_tensor(weight)
     with tf.GradientTape(persistent=True) as t:
-      t.watch(pulling_indices_tf)
-      t.watch(weight_tf)
-      cls_weights_tf = tf.reshape(
-          ca.get_clustered_weight(pulling_indices_tf), shape=(-1,))
-      t.watch(cls_weights_tf)
-      out_forward = ca.add_custom_gradients(cls_weights_tf, weight_tf)
-      grad_cls_weight = t.gradient(out_forward, cls_weights_tf)
-      grad_weight = t.gradient(out_forward, weight_tf)
+      t.watch(weight)
+      t.watch(cluster_centroids)
 
-      chk_output = tf.math.equal(grad_cls_weight, grad_weight)
-      chk_output_np = k.batch_get_value(chk_output)
+      out = clustering_algo.get_clustered_weight(
+        pulling_indices, original_weight=weight
+      )
 
-      self.assertSequenceEqual(chk_output_np, expected_output)
+    grad_original_weight = t.gradient(out, weight)
+    grad_cluster_centroids = t.gradient(out, cluster_centroids)
+    # Because of tf.gather, the grad will be of type tf.IndexedSlices
+    # Convert it back to a tf.tensor
+    grad_cluster_centroids = tf.convert_to_tensor(grad_cluster_centroids)
+
+    # grad_original_weight with respect to out should always be 1s
+    expected_grad_weight = tf.ones(shape=grad_original_weight.shape)
+
+    self.assertAllEqual(grad_original_weight, expected_grad_weight)
+    self.assertAllEqual(grad_cluster_centroids, expected_grad_centroids)
 
   @parameterized.parameters(
-      ([-0.800450444, 0.864694357],
-       [[0.220442653, 0.854694366, 0.0328432359, 0.506857157],
-        [0.0527950861, -0.659555554, -0.849919915, -0.54047],
-        [-0.305815876, 0.0865516588, 0.659202456, -0.355699599],
-        [-0.348868281, -0.662001, 0.6171574, -0.296582848]],
-       [[1, 1, 1, 1],
-        [1, 0, 0, 0],
-        [0, 1, 1, 0],
-        [0, 0, 1, 0]],
-       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-      )
+    (GradientAggregation.AVG,
+     [[1, 1, 1, 1],
+      [1, 0, 0, 0],
+      [0, 1, 1, 0],
+      [0, 0, 1, 0]],
+     [1, 1],
+    ),
+    (GradientAggregation.SUM,
+     [[1, 1, 1, 1],
+      [1, 0, 0, 0],
+      [0, 1, 1, 0],
+      [0, 0, 1, 0]],
+     [8, 8],
+     ),
+    (GradientAggregation.AVG,
+     [[1, 1, 1, 1],
+      [1, 1, 1, 0],
+      [0, 1, 1, 0],
+      [0, 0, 1, 0]],
+     [1, 1],
+     ),
+    (GradientAggregation.AVG,
+     [[1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1]],
+     [0, 1],
+    ),
+    (GradientAggregation.SUM,
+     [[1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1]],
+     [0, 16],
+    ),
   )
   def testDenseWeightsCAGrad(self,
-                             clustering_centroids,
-                             weight,
+                             cluster_gradient_aggregation,
                              pulling_indices,
-                             expected_output):
+                             expected_grad_centroids,
+                             ):
     """
     Verifies that the gradients of DenseWeightsCA work as expected.
     """
-    ca = clustering_registry.DenseWeightsCA(clustering_centroids)
-    self._check_gradients(ca, weight, pulling_indices, expected_output)
+    clustering_centroids = tf.Variable([-0.800450444, 0.864694357])
+    weight = tf.constant(
+     [[0.220442653, 0.854694366, 0.0328432359, 0.506857157],
+      [0.0527950861, -0.659555554, -0.849919915, -0.54047],
+      [-0.305815876, 0.0865516588, 0.659202456, -0.355699599],
+      [-0.348868281, -0.662001, 0.6171574, -0.296582848]]
+    )
+
+    clustering_algo = clustering_registry.DenseWeightsCA(
+        clustering_centroids, cluster_gradient_aggregation
+    )
+    self._check_gradients_clustered_weight(
+      clustering_algo,
+      weight,
+      pulling_indices,
+      expected_grad_centroids,
+    )
 
   @parameterized.parameters(
       ([-1, 1], [[0, 0, 1], [1, 1, 1]], [[-1, -1, 1], [1, 1, 1]]),
@@ -98,8 +148,11 @@ class ClusteringAlgorithmTest(parameterized.TestCase):
     """
     Verifies that DenseWeightsCA works as expected.
     """
-    ca = clustering_registry.DenseWeightsCA(clustering_centroids)
-    self._pull_values(ca, pulling_indices, expected_output)
+    clustering_centroids = tf.Variable(clustering_centroids, dtype=tf.float32)
+    clustering_algo = clustering_registry.DenseWeightsCA(
+        clustering_centroids, GradientAggregation.SUM
+    )
+    self._check_pull_values(clustering_algo, pulling_indices, expected_output)
 
   @parameterized.parameters(
       ([-1, 1], [0, 0, 0, 0, 1], [-1, -1, -1, -1, 1]),
@@ -112,30 +165,62 @@ class ClusteringAlgorithmTest(parameterized.TestCase):
     """
     Verifies that BiasWeightsCA works as expected.
     """
-    ca = clustering_registry.BiasWeightsCA(clustering_centroids)
-    self._pull_values(ca, pulling_indices, expected_output)
+    clustering_centroids = tf.Variable(clustering_centroids, dtype=tf.float32)
+    clustering_algo = clustering_registry.BiasWeightsCA(
+        clustering_centroids, GradientAggregation.SUM
+    )
+    self._check_pull_values(clustering_algo, pulling_indices, expected_output)
 
   @parameterized.parameters(
-      ([0.0, 3.0],
-       [[0.1, 0.1, 0.1],
-        [3.0, 3.0, 3.0],
-        [0.2, 0.2, 0.2]],
+      (GradientAggregation.AVG,
        [[0, 0, 0],
         [1, 1, 1],
         [0, 0, 0]],
-       [1, 1, 1, 1, 1, 1, 1, 1, 1]
-      )
+       [1, 1]
+      ),
+      (GradientAggregation.SUM,
+       [[0, 0, 0],
+        [1, 1, 1],
+        [0, 0, 0]],
+       [6, 3]
+      ),
+      (GradientAggregation.AVG,
+       [[0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]],
+       [1, 0]
+      ),
+      (GradientAggregation.SUM,
+       [[0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]],
+       [9, 0]
+       ),
   )
   def testConvolutionalWeightsCAGrad(self,
-                                     clustering_centroids,
-                                     weight,
+                                     cluster_gradient_aggregation,
                                      pulling_indices,
-                                     expected_output):
+                                     expected_grad_centroids,
+  ):
     """
     Verifies that the gradients of ConvolutionalWeightsCA work as expected.
     """
-    ca = clustering_registry.DenseWeightsCA(clustering_centroids)
-    self._check_gradients(ca, weight, pulling_indices, expected_output)
+    clustering_centroids = tf.Variable([0.0, 3.0], dtype=tf.float32)
+    weight = tf.constant(
+        [[0.1, 0.1, 0.1],
+         [3.0, 3.0, 3.0],
+         [0.2, 0.2, 0.2]])
+
+
+    clustering_algo = clustering_registry.ConvolutionalWeightsCA(
+        clustering_centroids, cluster_gradient_aggregation
+    )
+    self._check_gradients_clustered_weight(
+      clustering_algo,
+      weight,
+      pulling_indices,
+      expected_grad_centroids,
+    )
 
 
   @parameterized.parameters(
@@ -151,8 +236,11 @@ class ClusteringAlgorithmTest(parameterized.TestCase):
     """
     Verifies that ConvolutionalWeightsCA works as expected.
     """
-    ca = clustering_registry.ConvolutionalWeightsCA(clustering_centroids)
-    self._pull_values(ca, pulling_indices, expected_output)
+    clustering_centroids = tf.Variable(clustering_centroids, dtype=tf.float32)
+    clustering_algo = clustering_registry.ConvolutionalWeightsCA(
+        clustering_centroids, GradientAggregation.SUM
+    )
+    self._check_pull_values(clustering_algo, pulling_indices, expected_output)
 
 
 class CustomLayer(layers.Layer):
@@ -175,7 +263,7 @@ class ClusteringLookupRegistryTest(test.TestCase, parameterized.TestCase):
     also presented in the ClusteringLookup.
     """
     for layer, clustering_record in ClusterRegistry._LAYERS_WEIGHTS_MAP.items():
-      if clustering_record == []:
+      if not clustering_record:
         continue
 
       self.assertIn(layer, ClusteringLookupRegistry._LAYERS_RESHAPE_MAP)

--- a/tensorflow_model_optimization/python/core/clustering/keras/mnist_clusterable_layer_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/mnist_clusterable_layer_test.py
@@ -31,6 +31,8 @@ NUMBER_OF_CLUSTERS = 8
 
 
 class MyDenseLayer(keras.layers.Dense, clusterable_layer.ClusterableLayer):
+  def __init__(self, units, **kwargs):
+    super().__init__(units, **kwargs)
 
   def get_clusterable_weights(self):
     # Cluster kernel and bias.
@@ -62,8 +64,8 @@ class ClusterableWeightsCA(clustering_algorithm.AbstractClusteringAlgorithm):
 class MyClusterableLayer(keras.layers.Layer,
                          clusterable_layer.ClusterableLayer):
 
-  def __init__(self, units=32):
-    super(MyClusterableLayer, self).__init__()
+  def __init__(self, units=32, **kwargs):
+    super(MyClusterableLayer, self).__init__(**kwargs)
     self.units = units
 
   def build(self, input_shape):
@@ -73,10 +75,19 @@ class MyClusterableLayer(keras.layers.Layer,
         trainable=True,
     )
     self.b = self.add_weight(
-        shape=(self.units,), initializer='random_normal', trainable=False)
+      shape=(self.units,),
+      initializer="random_normal",
+      trainable=False,
+    )
+    self.built = True
 
   def call(self, inputs):
     return tf.matmul(inputs, self.w) + self.b
+
+  def get_config(self):
+    config = super(MyClusterableLayer, self).get_config()
+    config.update({"units": self.units})
+    return config
 
   def get_clusterable_weights(self):
     # Cluster only weights 'w'
@@ -168,6 +179,7 @@ def _cluster_model(model, number_of_clusters):
   clustered_model.fit(x_train, y_train, epochs=EPOCHS_FINE_TUNING)
 
   stripped_model = cluster.strip_clustering(clustered_model)
+
   stripped_model.compile(
       loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
       optimizer=opt,
@@ -175,10 +187,10 @@ def _cluster_model(model, number_of_clusters):
 
   return stripped_model
 
-
-def _get_number_of_unique_weights(stripped_model, layer_nr, weights_nr):
-  weights_as_list = stripped_model.layers[layer_nr].get_weights(
-  )[weights_nr].reshape(-1,).tolist()
+def _get_number_of_unique_weights(stripped_model, layer_nr, weight_name):
+  layer = stripped_model.layers[layer_nr]
+  weight = getattr(layer, weight_name)
+  weights_as_list = weight.numpy().reshape(-1,).tolist()
   nr_of_unique_weights = len(set(weights_as_list))
 
   return nr_of_unique_weights
@@ -196,14 +208,12 @@ class FunctionalTest(tf.test.TestCase):
     model = _build_model()
     _train_model(model)
 
-    # Checks that number of original weights('kernel') is greater than the
-    # number of clusters.
-    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 0)
+    # Checks that number of original weights('kernel') is greater than the number of clusters
+    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 'kernel')
     self.assertGreater(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
-    # Checks that number of original weights('bias') is greater than the number
-    # of clusters
-    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 1)
+    # Checks that number of original weights('bias') is greater than the number of clusters
+    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 'bias')
     self.assertGreater(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
     _, (x_test, y_test) = _get_dataset()
@@ -218,11 +228,11 @@ class FunctionalTest(tf.test.TestCase):
     self.assertGreater(results[1], 0.8)
 
     # checks 'kernel' weights of the last layer: MyDenseLayer
-    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 0)
+    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 'kernel')
     self.assertLessEqual(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
     # checks 'bias' weights of the last layer: MyDenseLayer
-    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 1)
+    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 'bias')
     self.assertLessEqual(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
   def testMnistClusterableLayer(self):
@@ -238,17 +248,18 @@ class FunctionalTest(tf.test.TestCase):
     model = _build_model_2()
     _train_model(model)
 
-    # Checks that number of original weights 'w' is greater than the number
-    # of clusters.
-    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 0)
+    # Checks that number of original weights 'w' is greater than the number of clusters.
+    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 'w')
     self.assertGreater(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
     clustered_model = _cluster_model(model, NUMBER_OF_CLUSTERS)
 
     # Checks clustered weights 'w'.
-    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 0)
+    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 'w')
     self.assertLessEqual(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
+    # Train again normally for sanity check
+    _train_model(clustered_model)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/mnist_clustering_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/mnist_clustering_test.py
@@ -97,10 +97,10 @@ def _cluster_model(model, number_of_clusters):
 
   return stripped_model
 
-
-def _get_number_of_unique_weights(stripped_model, layer_nr, weights_nr):
-  weights_as_list = stripped_model.layers[layer_nr].get_weights(
-  )[weights_nr].reshape(-1,).tolist()
+def _get_number_of_unique_weights(stripped_model, layer_nr, weight_name):
+  layer = stripped_model.layers[layer_nr]
+  weight = getattr(layer, weight_name)
+  weights_as_list = weight.numpy().reshape(-1, ).tolist()
   nr_of_unique_weights = len(set(weights_as_list))
 
   return nr_of_unique_weights
@@ -115,11 +115,11 @@ class FunctionalTest(tf.test.TestCase):
 
     # Checks that number of original weights('kernel') is greater than the
     # number of clusters
-    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 0)
+    nr_of_unique_weights = _get_number_of_unique_weights(model, -1, 'kernel')
     self.assertGreater(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
     # Record the number of unique values of 'bias'
-    nr_of_bias_weights = _get_number_of_unique_weights(model, -1, 1)
+    nr_of_bias_weights = _get_number_of_unique_weights(model, -1, 'bias')
     self.assertGreater(nr_of_bias_weights, NUMBER_OF_CLUSTERS)
 
     _, (x_test, y_test) = _get_dataset()
@@ -133,12 +133,13 @@ class FunctionalTest(tf.test.TestCase):
 
     self.assertGreater(results[1], 0.8)
 
-    nr_of_unique_weights = _get_number_of_unique_weights(clustered_model, -1, 0)
+    nr_of_unique_weights = _get_number_of_unique_weights(
+        clustered_model, -1, 'kernel')
     self.assertLessEqual(nr_of_unique_weights, NUMBER_OF_CLUSTERS)
 
     # checks that we don't cluster 'bias' weights
     clustered_nr_of_bias_weights = _get_number_of_unique_weights(
-        clustered_model, -1, 1)
+        clustered_model, -1, 'bias')
     self.assertEqual(nr_of_bias_weights, clustered_nr_of_bias_weights)
 
 

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry.py
@@ -393,7 +393,7 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
                          weights['pulling_indices_tf'].dtype)
       )
 
-      clustered_inputs = weights['clst_impl'].get_clustered_weight_forward(
+      clustered_inputs = weights['clst_impl'].get_clustered_weight(
           weights['pulling_indices_tf'], weights['ori_weights_vars_tf']
       )
       weights['set_kernel_weight'].assign(clustered_inputs)


### PR DESCRIPTION
This PR is two fold: a new feature Average Gradient Aggregation and a cleaning of the clustering codebase.

## Average Gradient Aggregation
Average Gradient Aggregation feature averages the gradient of each cluster centroid by the size of this cluster (the size being the number of child's weight belonging to the respective cluster).
### User API
We are letting users the choice between the existing implementation (Sum Gradient Aggregation) and the new implementation (Average Gradient Aggregation):
```python
tfmot.clustering.keras.cluster_weights(
    to_cluster, number_of_clusters, cluster_centroids_init, cluster_gradient_aggregation=GradientAggregation.SUM
)
```
With cluster_gradient_aggregation being an enum: either `GradientAggregation.SUM` (default) or `GradientAggregation.AVG`.
### Implementation detail
#### Sum Gradient Aggregation
![sum_grad](https://user-images.githubusercontent.com/30185046/115029879-59a6a380-9ebe-11eb-81eb-34f0c671c5ab.png)
With Sum Gradient Aggregation, the gradient of each centroid is simply computed through normal backpropagation: the gather operation will aggregate the gradient of the corresponding weights child's to their centroids. **This is a summation of gradients.**
`clustered_weight = tf.gather(cluster_centroids, pulling_indices)`
#### Average Gradient Aggregation
![avg_grad](https://user-images.githubusercontent.com/30185046/115031059-a9d23580-9ebf-11eb-8123-80aec455462f.png)
With Average Gradient Aggregation, the gradient of each centroids is modified with a `tf.custom_gradient` by dividing the current gradient by the size of the cluster (number of belonging weight's child). **This is an averaged summation of gradients.**
```python
@tf.custom_gradient
def average_centroids_gradient_by_cluster_size(cluster_centroids, cluster_sizes):
  def grad(d_cluster_centroids):
    # Average the gradient based on the number of weights belonging to each cluster
    d_cluster_centroids = tf.math.divide_no_nan(d_cluster_centroids, cluster_sizes)
    return d_cluster_centroids, None
  return cluster_centroids, grad

# Compute the size of each cluster (number of weights belonging to each cluster)
cluster_sizes = tf.math.bincount(
  arr=tf.cast(pulling_indices, dtype=tf.int32),
  minlength=tf.size(cluster_centroids),
  dtype=cluster_centroids.dtype,
)
# Modify the gradient of cluster_centroids to be averaged by cluster sizes
cluster_centroids = average_centroids_gradient_by_cluster_size(
  cluster_centroids,
  tf.stop_gradient(cluster_sizes),
)
# Gather the clustered weights based on cluster centroids and pulling indices
clustered_weight = tf.gather(cluster_centroids, pulling_indices)
```
### Results
Average Gradient Aggregation doesn't show strict performance improvement across all possible baselines, but does show improvement over some baselines. Based on these results, we decided to let users decide between the two aggregation methods, with Sum Gradient Aggregation being the default setting for backward-compatibility.

| Model      | Dataset | Number of clusters | SumGA accuracy | AvgGA accuracy | Delta accuracy |
| ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
| DS-CNN-L | Speech Commands | 8 | 94.03%  | 94.11% | +0.08% |
| MobileNetV2 | Imagenet  | 16 | 67.76% | 68.39% | +0.63% |
| DS-CNN-L | Speech Commands | 32 | 95.17%  | 95.25% | +0.08% |
| MobileNetV2 | Imagenet  | 32 | 69.658% | 69.664% | +0.006% |
| MobileNetV1 | Cifar10 | 16 | 94.40% | 94.43% | +0.03% |

## Clustering codebase cleaning
This cleaning was the first step allowing the implementation of the Average Gradient Aggregation feature.

- Fix bugs with all possible regularizers (kernel, bias and activity).
- clustering_algorithm.py: removed non-necessary reshape operations and fuse everything into get_clustered_weight.
- cluster_wrapper.py: simplification of the logic in the build and call function.
- cluster.py: simplification of the strip_clustering function.
- Addition of a series of tests.