### PR TITLE
[Clustering] Enable RNN layers

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_wrapper
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_centroids
+from tensorflow_model_optimization.python.core.clustering.keras.clustering_registry import ClusteringRegistry
 
 k = tf.keras.backend
 CustomObjectScope = tf.keras.utils.CustomObjectScope
@@ -236,6 +237,14 @@ def _cluster_weights(to_cluster, number_of_clusters, cluster_centroids_init,
       return layer
     if isinstance(layer, InputLayer):
       return layer.__class__.from_config(layer.get_config())
+    if isinstance(layer, tf.keras.layers.RNN):
+      return cluster_wrapper.ClusterWeightsRNN(
+        layer,
+        number_of_clusters,
+        cluster_centroids_init,
+        preserve_sparsity,
+        **kwargs,
+      )
 
     return cluster_wrapper.ClusterWeights(layer, number_of_clusters,
                                           cluster_centroids_init,
@@ -303,7 +312,7 @@ def strip_clustering(model):
       for (position_variable,
            weight_name) in layer.position_original_weights.items():
         # Add the clustered weights at the correct position
-        clustered_weight = getattr(layer.layer, weight_name)
+        clustered_weight = layer.get_weight_from_layer(weight_name)
         updated_weights.insert(position_variable, clustered_weight)
 
       # Construct a clean layer with the updated weights

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -344,5 +344,152 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
         callbacks=[CheckWeightsCallback()])
 
 
+class ClusterRNNIntegrationTest(tf.test.TestCase, parameterized.TestCase):
+  """Integration tests for clustering RNN layers."""
+
+  def setUp(self):
+    self.max_features = 10
+    self.maxlen = 2
+    self.batch_size = 32
+    self.x_train = np.random.random((64, self.maxlen))
+    self.y_train = np.random.randint(0, 2, (64,))
+
+    self.params_clustering = {
+      "number_of_clusters": 16,
+      "cluster_centroids_init": CentroidInitialization.KMEANS_PLUS_PLUS,
+    }
+
+  def _train(self, model):
+    model.compile(loss="binary_crossentropy", optimizer="adam", metrics=["accuracy"])
+    model.fit(
+      self.x_train,
+      self.y_train,
+      batch_size=self.batch_size,
+      epochs=1,
+    )
+
+  def _clusterTrainStrip(self, model):
+    clustered_model = cluster.cluster_weights(
+      model,
+      **self.params_clustering,
+    )
+    self._train(clustered_model)
+    stripped_model = cluster.strip_clustering(clustered_model)
+
+    return stripped_model
+
+  def __assertNbUniqueWeights(self, weight, expected_unique_weights):
+    nr_unique_weights = len(np.unique(weight.numpy().flatten()))
+    assert nr_unique_weights == expected_unique_weights
+
+  @keras_parameterized.run_all_keras_modes
+  def testClusterSimpleRNN(self):
+    model = keras.models.Sequential()
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
+    model.add(keras.layers.SimpleRNN(16, return_sequences=True))
+    model.add(keras.layers.SimpleRNN(16))
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("sigmoid"))
+
+    stripped_model = self._clusterTrainStrip(model)
+
+    self.__assertNbUniqueWeights(
+      weight=stripped_model.layers[1].cell.kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self.__assertNbUniqueWeights(
+      weight=stripped_model.layers[1].cell.recurrent_kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+
+    self._train(stripped_model)
+
+  @keras_parameterized.run_all_keras_modes
+  def testClusterLSTM(self):
+    model = keras.models.Sequential()
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
+    model.add(keras.layers.LSTM(16, return_sequences=True))
+    model.add(keras.layers.LSTM(16))
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("sigmoid"))
+
+    stripped_model = self._clusterTrainStrip(model)
+
+    self.__assertNbUniqueWeights(
+      weight=stripped_model.layers[1].cell.kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self.__assertNbUniqueWeights(
+      weight=stripped_model.layers[1].cell.recurrent_kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+
+    self._train(stripped_model)
+
+  @keras_parameterized.run_all_keras_modes
+  def testClusterGRU(self):
+    model = keras.models.Sequential()
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
+    model.add(keras.layers.GRU(16, return_sequences=True))
+    model.add(keras.layers.GRU(16))
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("sigmoid"))
+
+    stripped_model = self._clusterTrainStrip(model)
+
+    self.__assertNbUniqueWeights(
+      weight=stripped_model.layers[1].cell.kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self.__assertNbUniqueWeights(
+      weight=stripped_model.layers[1].cell.recurrent_kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+
+    self._train(stripped_model)
+
+  @keras_parameterized.run_all_keras_modes
+  def testClusterPeepholeLSTM(self):
+    model = keras.models.Sequential()
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
+    model.add(keras.layers.RNN(tf.keras.experimental.PeepholeLSTMCell(16)))
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("sigmoid"))
+
+    # PeepholeLSTM not supported yet.
+    with self.assertRaises(ValueError):
+      self._clusterTrainStrip(model)
+
+  @keras_parameterized.run_all_keras_modes
+  def testClusterBidirectional(self):
+    model = keras.models.Sequential()
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
+    model.add(keras.layers.Bidirectional(keras.layers.SimpleRNN(16)))
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("sigmoid"))
+
+    # Bidirectional not supported yet.
+    with self.assertRaises(ValueError):
+      self._clusterTrainStrip(model)
+
+  @keras_parameterized.run_all_keras_modes
+  def testClusterStackedRNNCells(self):
+    model = keras.models.Sequential()
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
+    model.add(
+      tf.keras.layers.RNN(
+        tf.keras.layers.StackedRNNCells(
+          [keras.layers.SimpleRNNCell(16) for _ in range(2)]
+        )
+      )
+    )
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("sigmoid"))
+
+    # StackedRNNCells not supported yet.
+    with self.assertRaises(ValueError):
+      self._clusterTrainStrip(model)
+
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -139,6 +139,12 @@ class ClusterWeights(Wrapper):
   def _make_layer_name(layer):
     return '{}_{}'.format('cluster', layer.name)
 
+  def get_weight_from_layer(self, weight_name):
+    return getattr(self.layer, weight_name)
+
+  def set_weight_to_layer(self, weight_name, new_weight):
+    setattr(self.layer, weight_name, new_weight)
+
   def build(self, input_shape):
     super(ClusterWeights, self).build(input_shape)
     self.build_input_shape = input_shape
@@ -148,7 +154,7 @@ class ClusterWeights(Wrapper):
       # Store the original weight in this wrapper
       # The child reference will be overridden in
       # update_clustered_weights_associations
-      original_weight = getattr(self.layer, weight_name)
+      original_weight = self.get_weight_from_layer(weight_name)
       self.original_clusterable_weights[weight_name] = original_weight
       setattr(self, 'original_weight_' + weight_name,
               original_weight)  # Track the variable
@@ -220,7 +226,7 @@ class ClusterWeights(Wrapper):
                                              self.sparsity_masks[weight_name])
 
       # Replace the weights with their clustered counterparts
-      setattr(self.layer, weight_name, clustered_weights)
+      self.set_weight_to_layer(weight_name, clustered_weights)
 
   def call(self, inputs, training=None, **kwargs):
     # Update cluster associations in order to set the latest weights
@@ -292,3 +298,13 @@ class ClusterWeights(Wrapper):
 
   def set_weights(self, weights):
     self.layer.set_weights(weights)
+
+
+class ClusterWeightsRNN(ClusterWeights):
+  """This wrapper augments a keras RNN layer so that the weights can be clustered."""
+
+  def get_weight_from_layer(self, weight_name):
+    return getattr(self.layer.cell, weight_name)
+
+  def set_weight_to_layer(self, weight_name, new_weight):
+    setattr(self.layer.cell, weight_name, new_weight)

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
@@ -133,6 +133,18 @@ class ClusteringLookupRegistry(object):
           'kernel': ConvolutionalWeightsCA,
           'bias': BiasWeightsCA
       },
+      layers.LSTM: {
+          'kernel': DenseWeightsCA,
+          'recurrent_kernel': DenseWeightsCA
+      },
+      layers.GRU: {
+          'kernel': DenseWeightsCA,
+          'recurrent_kernel': DenseWeightsCA
+      },
+      layers.SimpleRNN: {
+          'kernel': DenseWeightsCA,
+          'recurrent_kernel': DenseWeightsCA
+      },
   }
 
   @classmethod
@@ -235,38 +247,11 @@ class ClusteringRegistry(object):
       layers.LayerNormalization: [],
   }
 
-  _RNN_CELLS_WEIGHTS_MAP = {
-      # NOTE: RNN cells are added via compat.v1 and compat.v2 to support legacy
-      # TensorFlow 2.X behavior where the v2 RNN uses the v1 RNNCell instead of
-      # the v2 RNNCell.
-      tf.compat.v1.keras.layers.GRUCell: ['kernel', 'recurrent_kernel'],
-      tf.compat.v2.keras.layers.GRUCell: ['kernel', 'recurrent_kernel'],
-      tf.compat.v1.keras.layers.LSTMCell: ['kernel', 'recurrent_kernel'],
-      tf.compat.v2.keras.layers.LSTMCell: ['kernel', 'recurrent_kernel'],
-      tf.compat.v1.keras.experimental.PeepholeLSTMCell: [
-          'kernel', 'recurrent_kernel'
-      ],
-      tf.compat.v2.keras.experimental.PeepholeLSTMCell: [
-          'kernel', 'recurrent_kernel'
-      ],
-      tf.compat.v1.keras.layers.SimpleRNNCell: ['kernel', 'recurrent_kernel'],
-      tf.compat.v2.keras.layers.SimpleRNNCell: ['kernel', 'recurrent_kernel'],
-  }
-
-  _RNN_LAYERS = {
+  _SUPPORTED_RNN_LAYERS = {
       layers.GRU,
       layers.LSTM,
-      layers.RNN,
       layers.SimpleRNN,
   }
-
-  _RNN_CELLS_STR = ', '.join(str(_RNN_CELLS_WEIGHTS_MAP.keys()))
-
-  _RNN_CELL_ERROR_MSG = (
-      'RNN Layer {} contains cell type {} which is either not supported or does'
-      'not inherit ClusterableLayer. The cell must be one of {}, or implement '
-      'ClusterableLayer.'
-  )
 
   @classmethod
   def supports(cls, layer):
@@ -281,30 +266,16 @@ class ClusteringRegistry(object):
     """
     # Automatically enable layers with zero trainable weights.
     # Example: Reshape, AveragePooling2D, Maximum/Minimum, etc.
-    if not layer.trainable_weights:
+    if not layer.trainable_weights and not isinstance(layer, layers.RNN):
       return True
 
     if layer.__class__ in cls._LAYERS_WEIGHTS_MAP:
       return True
 
-    if layer.__class__ in cls._RNN_LAYERS:
-      for cell in cls._get_rnn_cells(layer):
-        if (cell.__class__ not in cls._RNN_CELLS_WEIGHTS_MAP
-            and not isinstance(cell, clusterable_layer.ClusterableLayer)):
-          return False
+    if layer.__class__ in cls._SUPPORTED_RNN_LAYERS:
       return True
 
     return False
-
-  @staticmethod
-  def _get_rnn_cells(rnn_layer):
-    if isinstance(rnn_layer.cell, layers.StackedRNNCells):
-      return rnn_layer.cell.cells
-    return [rnn_layer.cell]
-
-  @classmethod
-  def _is_rnn_layer(cls, layer):
-    return layer.__class__ in cls._RNN_LAYERS
 
   @classmethod
   def _weight_names(cls, layer):
@@ -323,7 +294,6 @@ class ClusteringRegistry(object):
 
     Returns:
       The modified layer object.
-
     """
 
     if not cls.supports(layer):
@@ -334,23 +304,16 @@ class ClusteringRegistry(object):
               for weight_name in cls._weight_names(layer)]
 
     def get_clusterable_weights_rnn():  # pylint: disable=missing-docstring
-      def get_clusterable_weights_rnn_cell(cell):
-        if cell.__class__ in cls._RNN_CELLS_WEIGHTS_MAP:
-          return [(weight, getattr(cell, weight))
-                  for weight in cls._RNN_CELLS_WEIGHTS_MAP[cell.__class__]]
+      if isinstance(layer.cell, clusterable_layer.ClusterableLayer):
+        raise ValueError("ClusterableLayer is not yet supported for RNNs based layer.")
 
-        if isinstance(cell, clusterable_layer.ClusterableLayer):
-          return cell.get_clusterable_weights()
-
-        raise ValueError(cls._RNN_CELL_ERROR_MSG.format(
-            layer.__class__, cell.__class__, cls._RNN_CELLS_WEIGHTS_MAP.keys()))
-
-      clusterable_weights = []
-      for rnn_cell in cls._get_rnn_cells(layer):
-        clusterable_weights.extend(get_clusterable_weights_rnn_cell(rnn_cell))
+      clusterable_weights = [
+        ('kernel', layer.cell.kernel),
+        ('recurrent_kernel', layer.cell.recurrent_kernel),
+      ]
       return clusterable_weights
 
-    if cls._is_rnn_layer(layer):
+    if layer.__class__ in cls._SUPPORTED_RNN_LAYERS:
       layer.get_clusterable_weights = get_clusterable_weights_rnn
     else:
       layer.get_clusterable_weights = get_clusterable_weights

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/BUILD
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/BUILD
@@ -1,0 +1,52 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)
+
+py_binary(
+    name = "imdb_lstm",
+    srcs = [
+        "imdb_lstm.py",
+    ],
+    python_version = "PY3",
+    deps = [
+        # numpy dep1,
+        # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
+    ],
+)
+
+py_binary(
+    name = "imdb_rnn",
+    srcs = [
+        "imdb_rnn.py",
+    ],
+    python_version = "PY3",
+    deps = [
+        # numpy dep1,
+        # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
+    ],
+)
+
+py_binary(
+    name = "imdb_gru",
+    srcs = [
+        "imdb_gru.py",
+    ],
+    python_version = "PY3",
+    deps = [
+        # numpy dep1,
+        # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
+    ],
+)

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_gru.py
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_gru.py
@@ -1,0 +1,72 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Train a GRU on the IMDB sentiment classification task.
+
+The dataset is actually too small for LSTM to be of any advantage
+compared to simpler, much faster methods such as TF-IDF+LogReg.
+"""
+
+from __future__ import print_function
+
+import tensorflow.keras as keras
+import tensorflow.keras.preprocessing.sequence as sequence
+from tensorflow_model_optimization.python.core.clustering.keras import cluster, cluster_config
+
+
+max_features = 20000
+maxlen = 100  # cut texts after this number of words
+batch_size = 32
+
+print("Loading data...")
+(x_train,
+ y_train), (x_test,
+            y_test) = keras.datasets.imdb.load_data(num_words=max_features)
+print(len(x_train), "train sequences")
+print(len(x_test), "test sequences")
+
+print("Pad sequences (samples x time)")
+x_train = sequence.pad_sequences(x_train, maxlen=maxlen)
+x_test = sequence.pad_sequences(x_test, maxlen=maxlen)
+print("x_train shape:", x_train.shape)
+print("x_test shape:", x_test.shape)
+
+print("Build model...")
+model = keras.models.Sequential()
+
+model.add(keras.layers.Embedding(max_features, 128, input_length=maxlen))
+model.add(keras.layers.GRU(128))
+model.add(keras.layers.Dropout(0.5))
+model.add(keras.layers.Dense(1))
+model.add(keras.layers.Activation("sigmoid"))
+
+model = cluster.cluster_weights(
+  model,
+  number_of_clusters=16,
+  cluster_centroids_init=cluster_config.CentroidInitialization.KMEANS_PLUS_PLUS,
+)
+
+model.compile(loss="binary_crossentropy",
+              optimizer="adam",
+              metrics=["accuracy"])
+
+
+print("Train...")
+model.fit(x_train, y_train, batch_size=batch_size, epochs=3,
+          validation_data=(x_test, y_test))
+score, acc = model.evaluate(x_test, y_test,
+                            batch_size=batch_size)
+
+print("Test score:", score)
+print("Test accuracy:", acc)

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_lstm.py
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_lstm.py
@@ -1,0 +1,71 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Train a LSTM on the IMDB sentiment classification task.
+
+The dataset is actually too small for LSTM to be of any advantage
+compared to simpler, much faster methods such as TF-IDF+LogReg.
+"""
+
+from __future__ import print_function
+
+import tensorflow.keras as keras
+import tensorflow.keras.preprocessing.sequence as sequence
+
+from tensorflow_model_optimization.python.core.clustering.keras import cluster, cluster_config
+
+max_features = 20000
+maxlen = 100  # cut texts after this number of words
+batch_size = 32
+
+print("Loading data...")
+(x_train,
+ y_train), (x_test,
+            y_test) = keras.datasets.imdb.load_data(num_words=max_features)
+print(len(x_train), "train sequences")
+print(len(x_test), "test sequences")
+
+print("Pad sequences (samples x time)")
+x_train = sequence.pad_sequences(x_train, maxlen=maxlen)
+x_test = sequence.pad_sequences(x_test, maxlen=maxlen)
+print("x_train shape:", x_train.shape)
+print("x_test shape:", x_test.shape)
+
+print("Build model...")
+model = keras.models.Sequential()
+
+model.add(keras.layers.Embedding(max_features, 128, input_length=maxlen))
+model.add(keras.layers.LSTM(128))
+model.add(keras.layers.Dropout(0.5))
+model.add(keras.layers.Dense(1))
+model.add(keras.layers.Activation("sigmoid"))
+
+model = cluster.cluster_weights(
+  model,
+  number_of_clusters=16,
+  cluster_centroids_init=cluster_config.CentroidInitialization.KMEANS_PLUS_PLUS,
+)
+
+model.compile(loss="binary_crossentropy",
+              optimizer="adam",
+              metrics=["accuracy"])
+
+print("Train...")
+model.fit(x_train, y_train, batch_size=batch_size, epochs=3,
+          validation_data=(x_test, y_test))
+score, acc = model.evaluate(x_test, y_test,
+                            batch_size=batch_size)
+
+print("Test score:", score)
+print("Test accuracy:", acc)

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_rnn.py
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_rnn.py
@@ -1,0 +1,72 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Train a SimpleRNN on the IMDB sentiment classification task.
+
+The dataset is actually too small for LSTM to be of any advantage
+compared to simpler, much faster methods such as TF-IDF+LogReg.
+"""
+
+from __future__ import print_function
+
+import tensorflow.keras as keras
+import tensorflow.keras.preprocessing.sequence as sequence
+from tensorflow_model_optimization.python.core.clustering.keras import cluster, cluster_config
+
+
+max_features = 20000
+maxlen = 100  # cut texts after this number of words
+batch_size = 32
+
+print("Loading data...")
+(x_train,
+ y_train), (x_test,
+            y_test) = keras.datasets.imdb.load_data(num_words=max_features)
+print(len(x_train), "train sequences")
+print(len(x_test), "test sequences")
+
+print("Pad sequences (samples x time)")
+x_train = sequence.pad_sequences(x_train, maxlen=maxlen)
+x_test = sequence.pad_sequences(x_test, maxlen=maxlen)
+print("x_train shape:", x_train.shape)
+print("x_test shape:", x_test.shape)
+
+print("Build model...")
+model = keras.models.Sequential()
+
+model.add(keras.layers.Embedding(max_features, 128, input_length=maxlen))
+model.add(keras.layers.SimpleRNN(128))
+model.add(keras.layers.Dropout(0.5))
+model.add(keras.layers.Dense(1))
+model.add(keras.layers.Activation("sigmoid"))
+
+model = cluster.cluster_weights(
+  model,
+  number_of_clusters=16,
+  cluster_centroids_init=cluster_config.CentroidInitialization.KMEANS_PLUS_PLUS,
+)
+
+model.compile(loss="binary_crossentropy",
+              optimizer="adam",
+              metrics=["accuracy"])
+
+
+print("Train...")
+model.fit(x_train, y_train, batch_size=batch_size, epochs=3,
+          validation_data=(x_test, y_test))
+score, acc = model.evaluate(x_test, y_test,
+                            batch_size=batch_size)
+
+print("Test score:", score)
+print("Test accuracy:", acc)


### PR DESCRIPTION
This PR enables the support of RNN layers in clustering.

### State of support
Here is the current state of support for RNN:
| Type of RNN      | Status |
| ----------- | ----------- |
| RNNSimple      | ✅       |
| LSTM      | ✅       |
| GRU      | ✅       |
| PeepholeLSTM      | ❌       |
| BidirectionalRNN | ❌       |
| StackedRNN | ❌       |

### Sanity check results
To confirm that the implementation seems robust enough, we ran some experiments on the IMDB dataset and compared accuracies to the existing pruning implementation with a LSTM layer.

**Setup**: Direct pruning/clustering from random weight (no finetuning) for 3 epochs on the IMDB dataset. 0.7% sparsity for pruning or 16 clusters for clustering.
| Type of RNN      | Accuracy |
| ----------- | ----------- |
| **LSTM (pruning baseline)**      | **0.8485** |
| LSTM (clustering)     | 0.8468       |
| GRU (clustering)     | 0.8536 |
| SimpleRNN (clustering) | 0.7690      |