### PR TITLE
[Collaborative optimization] Pruning-Clustering-preserving Quantization Aware Training

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/BUILD
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/BUILD
@@ -35,6 +35,7 @@ py_strict_library(
     ],
     srcs_version = "PY3",
     deps = [
+        ":cluster_utils",
         # tensorflow dep1,
         "//tensorflow_model_optimization/python/core/clustering/keras:clustering_registry",
         "//tensorflow_model_optimization/python/core/quantization/keras:quant_ops",
@@ -61,6 +62,23 @@ py_test(
     ],
 )
 
+py_test(
+    name = "mnist_prune_cluster_preserve_qat_test",
+    srcs = [
+        "mnist_prune_cluster_preserve_qat_test.py",
+    ],
+    python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        # tensorflow dep1,
+        ":default_8bit_cluster_preserve_quantize_scheme",
+        "//tensorflow_model_optimization/python/core/quantization/keras:quantize",
+        "//tensorflow_model_optimization/python/core/sparsity/keras:prune",
+        "//tensorflow_model_optimization/python/core/sparsity/keras:pruning_callbacks",
+        "//tensorflow_model_optimization/python/core/clustering/keras/experimental:cluster",
+    ]
+)
+
 py_strict_library(
     name = "default_8bit_cluster_preserve_quantize_scheme",
     srcs = [
@@ -70,5 +88,23 @@ py_strict_library(
     deps = [
         ":cluster_preserve_quantize_registry",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_scheme",
+    ],
+)
+
+py_test(
+    name = "cluster_preserve_integration_test",
+    srcs = [
+        "cluster_preserve_integration_test.py",
+    ],
+    python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":default_8bit_cluster_preserve_quantize_scheme",
+        # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras:clustering_registry",
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
+        "//tensorflow_model_optimization/python/core/clustering/keras/experimental:cluster",
+        "//tensorflow_model_optimization/python/core/quantization/keras:quantize_config",
+        "//tensorflow_model_optimization/python/core/quantization/keras:quantize"
     ],
 )

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_integration_test.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_integration_test.py
@@ -1,0 +1,439 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Integration tests for CQAT, PCQAT cases."""
+from absl.testing import parameterized
+
+import tensorflow as tf
+import numpy as np
+
+from tensorflow.python.keras import keras_parameterized
+from tensorflow_model_optimization.python.core.clustering.keras import cluster
+from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
+from tensorflow_model_optimization.python.core.quantization.keras import quantize
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.cluster_preserve import (
+    default_8bit_cluster_preserve_quantize_scheme,)
+from tensorflow_model_optimization.python.core.clustering.keras.experimental import cluster as experimental_cluster
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.cluster_preserve.cluster_utils import (
+    strip_clustering_cqat,)
+
+layers = tf.keras.layers
+
+
+@keras_parameterized.run_all_keras_modes
+class ClusterPreserveIntegrationTest(tf.test.TestCase, parameterized.TestCase):
+  def setUp(self):
+    super(ClusterPreserveIntegrationTest, self).setUp()
+    self.cluster_params = {
+        'number_of_clusters': 4,
+        'cluster_centroids_init': cluster_config.CentroidInitialization.LINEAR
+    }
+
+  def compile_and_fit(self, model):
+    """ Here we compile and fit the model."""
+    model.compile(
+        loss=tf.keras.losses.categorical_crossentropy,
+        optimizer='adam',
+        metrics=['accuracy'],
+    )
+    model.fit(
+        np.random.rand(20, 10),
+        tf.keras.utils.to_categorical(np.random.randint(5, size=(20, 1)), 5),
+        batch_size=20)
+
+  @staticmethod
+  def _get_number_of_unique_weights(stripped_model, layer_nr, weight_name):
+    layer = stripped_model.layers[layer_nr]
+    if isinstance(layer, quantize.quantize_wrapper.QuantizeWrapper):
+      for weight_item in layer.trainable_weights:
+        if weight_name in weight_item.name:
+          weight = weight_item
+    else:
+      weight = getattr(layer, weight_name)
+    weights_as_list = weight.numpy().flatten()
+    nr_of_unique_weights = len(set(weights_as_list))
+    return nr_of_unique_weights
+
+  @staticmethod
+  def _get_sparsity(model):
+    sparsity_list = []
+    for layer in model.layers:
+      for weights in layer.trainable_weights:
+        if 'kernel' in weights.name:
+          np_weights = tf.keras.backend.get_value(weights)
+          sparsity = 1.0 - np.count_nonzero(np_weights) / float(
+              np_weights.size)
+          sparsity_list.append(sparsity)
+
+    return sparsity_list
+
+  @staticmethod
+  def _get_clustered_model(preserve_sparsity):
+    """Cluster the (sparse) model and return clustered_model."""
+    tf.random.set_seed(1)
+    original_model = tf.keras.Sequential([
+        layers.Dense(5, activation='softmax', input_shape=(10,)),
+        layers.Flatten(),
+    ])
+
+    # Manually set sparsity in the Dense layer if preserve_sparsity is on
+    if preserve_sparsity:
+      first_layer_weights = original_model.layers[0].get_weights()
+      first_layer_weights[0][:][0:2] = 0.0
+      original_model.layers[0].set_weights(first_layer_weights)
+
+    # Start the sparsity-aware clustering
+    clustering_params = {
+        'number_of_clusters': 4,
+        'cluster_centroids_init': cluster_config.CentroidInitialization.LINEAR,
+        'preserve_sparsity': True
+    }
+
+    clustered_model = experimental_cluster.cluster_weights(
+        original_model, **clustering_params)
+
+    return clustered_model
+
+  def _pcqat_training(self, preserve_sparsity, quant_aware_annotate_model):
+    """PCQAT training on the input model."""
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme(preserve_sparsity))
+
+    self.compile_and_fit(quant_aware_model)
+
+    stripped_pcqat_model = strip_clustering_cqat(quant_aware_model)
+
+    # Check the unique weights of clustered_model and pcqat_model
+    # layer 0 is the quantize_layer
+    num_of_unique_weights_pcqat = self._get_number_of_unique_weights(
+        stripped_pcqat_model, 1, 'kernel')
+
+    sparsity_pcqat = self._get_sparsity(stripped_pcqat_model)
+
+    return sparsity_pcqat, num_of_unique_weights_pcqat
+
+  def testEndToEndClusterPreserve(self):
+    """Verifies that we can run CQAT end to end,
+    when the whole model is quantized."""
+    original_model = tf.keras.Sequential([
+        layers.Dense(5, activation='softmax', input_shape=(10,))
+    ])
+    clustered_model = cluster.cluster_weights(
+        original_model,
+        **self.cluster_params)
+    self.compile_and_fit(clustered_model)
+    clustered_model = cluster.strip_clustering(clustered_model)
+    num_of_unique_weights_clustering = self._get_number_of_unique_weights(
+        clustered_model, 0, 'kernel')
+
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(clustered_model))
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme())
+
+    self.compile_and_fit(quant_aware_model)
+    stripped_cqat_model = strip_clustering_cqat(quant_aware_model)
+
+    # Check the unique weights of a certain layer of
+    # clustered_model and pcqat_model
+    num_of_unique_weights_cqat = self._get_number_of_unique_weights(
+        stripped_cqat_model, 1, 'kernel')
+    self.assertAllEqual(num_of_unique_weights_clustering,
+                        num_of_unique_weights_cqat)
+
+  def testEndToEndClusterPreservePerLayer(self):
+    """Verifies that we can run CQAT end to end,
+    when the model is quantized per layers."""
+    original_model = tf.keras.Sequential([
+        layers.Dense(5, activation='relu', input_shape=(10,)),
+        layers.Dense(5, activation='softmax', input_shape=(10,))
+    ])
+    clustered_model = cluster.cluster_weights(
+        original_model,
+        **self.cluster_params)
+    self.compile_and_fit(clustered_model)
+    clustered_model = cluster.strip_clustering(clustered_model)
+    num_of_unique_weights_clustering = self._get_number_of_unique_weights(
+        clustered_model, 1, 'kernel')
+
+    def apply_quantization_to_dense(layer):
+      if isinstance(layer, tf.keras.layers.Dense):
+        return quantize.quantize_annotate_layer(layer)
+      return layer
+
+    quant_aware_annotate_model = tf.keras.models.clone_model(
+        clustered_model,
+        clone_function=apply_quantization_to_dense,
+    )
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme())
+
+    self.compile_and_fit(quant_aware_model)
+    stripped_cqat_model = strip_clustering_cqat(
+        quant_aware_model)
+
+    # Check the unique weights of a certain layer of
+    # clustered_model and pcqat_model
+    num_of_unique_weights_cqat = self._get_number_of_unique_weights(
+        stripped_cqat_model, 2, 'kernel')
+    self.assertAllEqual(num_of_unique_weights_clustering,
+                        num_of_unique_weights_cqat)
+
+  def testEndToEndClusterPreserveOneLayer(self):
+    """Verifies that we can run CQAT end to end,
+    when the model is quantized only for a single layer."""
+    original_model = tf.keras.Sequential([
+        layers.Dense(5, activation='relu', input_shape=(10,)),
+        layers.Dense(5, activation='softmax', input_shape=(10,), name='qat')
+    ])
+    clustered_model = cluster.cluster_weights(
+        original_model,
+        **self.cluster_params)
+    self.compile_and_fit(clustered_model)
+    clustered_model = cluster.strip_clustering(clustered_model)
+    num_of_unique_weights_clustering = self._get_number_of_unique_weights(
+        clustered_model, 1, 'kernel')
+
+    def apply_quantization_to_dense(layer):
+      if isinstance(layer, tf.keras.layers.Dense):
+        if layer.name == 'qat':
+          return quantize.quantize_annotate_layer(layer)
+      return layer
+
+    quant_aware_annotate_model = tf.keras.models.clone_model(
+        clustered_model,
+        clone_function=apply_quantization_to_dense,
+    )
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme())
+
+    self.compile_and_fit(quant_aware_model)
+
+    stripped_cqat_model = strip_clustering_cqat(
+        quant_aware_model)
+
+    # Check the unique weights of a certain layer of
+    # clustered_model and pcqat_model
+    num_of_unique_weights_cqat = self._get_number_of_unique_weights(
+        stripped_cqat_model, 1, 'kernel')
+    self.assertAllEqual(num_of_unique_weights_clustering,
+                        num_of_unique_weights_cqat)
+
+  def testEndToEndPruneClusterPreserveQAT(self):
+    """Verifies that we can run PCQAT end to end when we quantize the whole
+    model."""
+    preserve_sparsity = True
+    clustered_model = self._get_clustered_model(preserve_sparsity)
+    # Save the kernel weights
+    first_layer_weights = clustered_model.layers[0].weights[1]
+    stripped_model_before_tuning = cluster.strip_clustering(
+        clustered_model)
+    nr_of_unique_weights_before = self._get_number_of_unique_weights(
+        stripped_model_before_tuning, 0, 'kernel')
+
+    self.compile_and_fit(clustered_model)
+
+    stripped_model_clustered = cluster.strip_clustering(clustered_model)
+    weights_after_tuning = stripped_model_clustered.layers[0].kernel
+    nr_of_unique_weights_after = self._get_number_of_unique_weights(
+        stripped_model_clustered, 0, 'kernel')
+
+    # Check after sparsity-aware clustering, despite zero centroid can drift,
+    # the final number of unique weights remains the same
+    self.assertEqual(nr_of_unique_weights_before, nr_of_unique_weights_after)
+
+    # Check that the zero weights stayed the same before and after tuning.
+    # There might be new weights that become zeros but sparsity-aware
+    # clustering preserves the original zero weights in the original positions
+    # of the weight array
+    self.assertTrue(
+        np.array_equal(first_layer_weights[:][0:2],
+                       weights_after_tuning[:][0:2]))
+
+    # Check sparsity before the input of PCQAT
+    sparsity_pruning = self._get_sparsity(stripped_model_clustered)
+
+    # PCQAT: when the preserve_sparsity flag is True, the PCQAT should work
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(stripped_model_clustered)
+    )
+
+    # When preserve_sparsity is True in PCQAT, the final sparsity of
+    # the layer stays the same or larger than that of the input layer
+    preserve_sparsity = True
+    sparsity_pcqat, unique_weights_pcqat = self._pcqat_training(
+        preserve_sparsity, quant_aware_annotate_model)
+    self.assertAllGreaterEqual(np.array(sparsity_pcqat),
+                               sparsity_pruning[0])
+    self.assertAllEqual(nr_of_unique_weights_after, unique_weights_pcqat)
+
+  def testPassingNonPrunedModelToPCQAT(self):
+    """Verifies that we can run PCQAT as CQAT if the
+    input model is not pruned."""
+    preserve_sparsity = False
+    clustered_model = self._get_clustered_model(preserve_sparsity)
+
+    clustered_model = cluster.strip_clustering(clustered_model)
+    nr_of_unique_weights_after = self._get_number_of_unique_weights(
+        clustered_model, 0, 'kernel')
+
+    # Check after plain clustering, if there are no zero weights,
+    # PCQAT falls back to CQAT
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(clustered_model)
+    )
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme(True))
+
+    self.compile_and_fit(quant_aware_model)
+    stripped_pcqat_model = strip_clustering_cqat(
+        quant_aware_model)
+
+    # Check the unique weights of clustered_model and pcqat_model
+    num_of_unique_weights_pcqat = self._get_number_of_unique_weights(
+        stripped_pcqat_model, 1, 'kernel')
+    self.assertAllEqual(nr_of_unique_weights_after,
+                        num_of_unique_weights_pcqat)
+
+  @parameterized.parameters((0.), (2.))
+  def testPassingModelWithUniformWeightsToPCQAT(self, uniform_weights):
+    """Verifies that when the pruned_clustered_model has uniform weights, it
+    won't break PCQAT."""
+    preserve_sparsity = True
+    original_model = tf.keras.Sequential([
+        layers.Dense(5, activation='softmax', input_shape=(10,)),
+        layers.Flatten(),
+    ])
+
+    # Manually set all weights to the same value in the Dense layer
+    first_layer_weights = original_model.layers[0].get_weights()
+    first_layer_weights[0][:] = uniform_weights
+    original_model.layers[0].set_weights(first_layer_weights)
+
+    # Start the sparsity-aware clustering
+    clustering_params = {
+        'number_of_clusters': 4,
+        'cluster_centroids_init': cluster_config.CentroidInitialization.LINEAR,
+        'preserve_sparsity': True
+    }
+
+    clustered_model = experimental_cluster.cluster_weights(
+        original_model, **clustering_params)
+    clustered_model = cluster.strip_clustering(clustered_model)
+
+    nr_of_unique_weights_after = self._get_number_of_unique_weights(
+        clustered_model, 0, 'kernel')
+    sparsity_pruning = self._get_sparsity(clustered_model)
+
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(clustered_model)
+    )
+
+    sparsity_pcqat, unique_weights_pcqat = self._pcqat_training(
+        preserve_sparsity, quant_aware_annotate_model)
+    self.assertAllGreaterEqual(np.array(sparsity_pcqat),
+                               sparsity_pruning[0])
+    self.assertAllEqual(nr_of_unique_weights_after, unique_weights_pcqat)
+
+  def testTrainableWeightsBehaveCorrectlyDuringPCQAT(self):
+    """Verifies that during the training of PCQAT model the
+    zero centroid masks stay the same and trainable variables
+    are updating between epochs."""
+    preserve_sparsity = True
+    clustered_model = self._get_clustered_model(preserve_sparsity)
+    clustered_model = cluster.strip_clustering(clustered_model)
+
+    # Apply PCQAT
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(clustered_model)
+    )
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme(True))
+
+    quant_aware_model.compile(
+        loss=tf.keras.losses.categorical_crossentropy,
+        optimizer='adam',
+        metrics=['accuracy'],
+    )
+
+    class CheckCentroidsAndTrainableVarsCallback(tf.keras.callbacks.Callback):
+      """Check the updates of trainable variables and centroid masks."""
+      def on_epoch_begin(self, batch, logs=None):
+        # Check cluster centroids have the zero in the right position
+        vars_dictionary = self.model.layers[1]._weight_vars[0][2]
+        self.centroid_mask = vars_dictionary['centroids_mask']
+        self.zero_centroid_index_begin = np.where(
+            self.centroid_mask == 0)[0]
+
+        # Check trainable weights before training
+        self.layer_kernel = (
+            self.model.layers[1].weights[3].numpy()
+        )
+        self.original_weight = vars_dictionary['ori_weights_vars_tf'].numpy()
+        self.centroids = vars_dictionary['cluster_centroids_tf'].numpy()
+
+      def on_epoch_end(self, batch, logs=None):
+        # Check the index of the zero centroids are not changed after training
+        vars_dictionary = self.model.layers[1]._weight_vars[0][2]
+        self.zero_centroid_index_end = np.where(
+            vars_dictionary['centroids_mask'] == 0)[0]
+        assert np.array_equal(
+            self.zero_centroid_index_begin,
+            self.zero_centroid_index_end
+        )
+
+        # Check trainable variables after training are updated
+        assert not np.array_equal(
+            self.layer_kernel,
+            self.model.layers[1].weights[3].numpy()
+        )
+        assert not np.array_equal(
+            self.original_weight,
+            vars_dictionary['ori_weights_vars_tf'].numpy()
+        )
+        assert not np.array_equal(
+            self.centroids,
+            vars_dictionary['cluster_centroids_tf'].numpy()
+        )
+
+    # Use many epochs to verify layer's kernel weights are updating because
+    # they can stay the same after being trained using only the first batch
+    # of data for instance
+    quant_aware_model.fit(np.random.rand(20, 10),
+                          tf.keras.utils.to_categorical(
+                              np.random.randint(5, size=(20, 1)), 5),
+                          steps_per_epoch=5,
+                          epochs=3,
+                          callbacks=[CheckCentroidsAndTrainableVarsCallback()])
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry.py
@@ -15,6 +15,7 @@
 """Registry responsible for built-in keras classes."""
 
 import tensorflow as tf
+import logging
 
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
 from tensorflow_model_optimization.python.core.quantization.keras import quant_ops
@@ -22,8 +23,16 @@ from tensorflow_model_optimization.python.core.quantization.keras import quantiz
 from tensorflow_model_optimization.python.core.quantization.keras.default_8bit import default_8bit_quantize_registry
 from tensorflow_model_optimization.python.core.quantization.keras.default_8bit import default_8bit_quantizers
 
-K = tf.keras.backend
 layers = tf.keras.layers
+K = tf.keras.backend
+
+CLUSTER_CENTROIDS = 'cluster_centroids_tf'
+PULLING_INDICES = 'pulling_indices_tf'
+ORIGINAL_WEIGHTS = 'ori_weights_vars_tf'
+WEIGHT_NAME = 'weight_name'
+CLUSTERING_IMPL = 'clst_impl'
+CENTROIDS_MASK = 'centroids_mask'
+SPARSITY_MASK = 'sparsity_mask'
 
 
 def get_unique(t):
@@ -69,7 +78,7 @@ class _ClusterPreserveInfo(object):
 
 
 class ClusterPreserveQuantizeRegistry(object):
-  """ClusterPreserveQuantizeRegistry for built-in keras layers."""
+  """ClusterPreserveQuantizeRegistry is for built-in keras layers."""
   # The keys represent built-in keras layers; the first values represent the
   # the variables within the layers which hold the kernel weights, second
   # values represent the class name of quantization configuration for layers.
@@ -118,12 +127,12 @@ class ClusterPreserveQuantizeRegistry(object):
       layers.DepthwiseConv2D,
   })
 
-  def __init__(self):
+  def __init__(self, preserve_sparsity):
     self._config_quantizer_map = {
         'Default8BitQuantizeConfig':
-        ClusterPreserveDefault8BitWeightsQuantizer(),
+        ClusterPreserveDefault8BitWeightsQuantizer(preserve_sparsity),
         'Default8BitConvQuantizeConfig':
-        ClusterPreserveDefault8BitConvWeightsQuantizer(),
+        ClusterPreserveDefault8BitConvWeightsQuantizer(preserve_sparsity),
     }
 
   @classmethod
@@ -132,19 +141,17 @@ class ClusterPreserveQuantizeRegistry(object):
 
     Args:
       layer: The layer to check for trainable weights.
-
     Returns:
       True/False whether the layer has trainable weights.
     """
-    return not layer.trainable_weights
+    return len(layer.trainable_weights) == 0
 
   @classmethod
   def _disable_cluster_preserve(cls, layer):
-    """Returns whether disable this layer for preserving clusters.
+    """Returns whether to disable this layer for preserving clusters.
 
     Args:
       layer: The layer to check for disabling.
-
     Returns:
       True/False whether disabling this layer for preserving clusters.
     """
@@ -156,7 +163,6 @@ class ClusterPreserveQuantizeRegistry(object):
 
     Args:
       layer: The layer to check for support.
-
     Returns:
       True/False whether the layer type is supported.
     """
@@ -178,34 +184,6 @@ class ClusterPreserveQuantizeRegistry(object):
 
     return cls._LAYERS_CONFIG_MAP[layer.__class__].weight_attrs
 
-  @classmethod
-  def get_cluster_preservable_weights(cls, layer):
-    """Get cluster preservable weights from keras layer.
-
-    Args:
-      layer: instance of keras layer
-
-    Returns:
-      List of cluster preservable weights
-    """
-    return [getattr(layer, weight) for weight in cls._weight_names(layer)]
-
-  @classmethod
-  def get_suppport_quantize_config_names(cls, layer):
-    """Get class name of supported quantize config for layer.
-
-    Args:
-      layer: instance of keras layer
-
-    Returns:
-      List of supported quantize config class name.
-    """
-    # layers without trainable weights don't need quantize_config for cqat
-    if cls._no_trainable_weights(layer):
-      return []
-
-    return cls._LAYERS_CONFIG_MAP[layer.__class__].quantize_config_attrs
-
   def apply_cluster_preserve_quantize_config(self, layer, quantize_config):
     """Applies cluster-preserve weight quantizer.
 
@@ -213,7 +191,6 @@ class ClusterPreserveQuantizeRegistry(object):
       layer: The layer to check for support.
       quantize_config: quantization config for supporting cluster preservation
       on clustered weights
-
     Returns:
       The quantize_config with addon cluster preserve weight_quantizer.
     """
@@ -242,13 +219,16 @@ class ClusterPreserveQuantizeRegistry(object):
 class Default8bitClusterPreserveQuantizeRegistry(
     ClusterPreserveQuantizeRegistry):
   """Default 8 bit ClusterPreserveQuantizeRegistry."""
+  def __init__(self, preserve_sparsity):
+    super(Default8bitClusterPreserveQuantizeRegistry, self).__init__(
+        preserve_sparsity)
+    self.preserve_sparsity = preserve_sparsity
 
   def get_quantize_config(self, layer):
-    """Returns the quantization config with addon cluster preserve weight_quantizer for the given layer.
+    """Returns the quantization config with weight_quantizer for a given layer.
 
     Args:
       layer: input layer to return quantize config for.
-
     Returns:
       Returns the quantization config for cluster preserve weight_quantizer.
     """
@@ -264,9 +244,9 @@ class Default8bitClusterPreserveQuantizeRegistry(
 
 class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
   """Quantize weights while preserving clusters."""
-
-  def __init__(self, num_bits, per_axis, symmetric, narrow_range):
-    """ClusterPreserveDefaultWeightsQuantizer.
+  def __init__(
+      self, num_bits, per_axis, symmetric, narrow_range, preserve_sparsity):
+    """ClusterPreserveDefaultWeightsQuantizer
 
     Args:
       num_bits: Number of bits for quantization
@@ -277,6 +257,8 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
       narrow_range: In case of 8 bits, narrow_range nudges the quantized range
         to be [-127, 127] instead of [-128, 127]. This ensures symmetric
         range has 0 as the centre.
+      preserve_sparsity: Whether to apply prune-cluster-preserving quantization
+        aware training.
     """
     super(ClusterPreserveDefaultWeightsQuantizer, self).__init__(
         num_bits=num_bits,
@@ -284,9 +266,12 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
         symmetric=symmetric,
         narrow_range=narrow_range,
     )
+    self.preserve_sparsity = preserve_sparsity
 
   def _build_clusters(self, name, layer):
-    """Extract the cluster centroids and cluster indices from the pretrained clustered model.
+    """ Extract the cluster centroids and cluster indices
+        from the pretrained clustered model when the input
+        layer is clustered.
 
     Args:
       name: Name of weights in layer.
@@ -297,68 +282,80 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
       the pretrained flag for marking the first training
       epoch, and weight name.
     """
+    result = {}
     weights = getattr(layer.layer, name)
+    if self.preserve_sparsity and not tf.reduce_any(weights == 0):
+      self.preserve_sparsity = False
+      logging.warning(
+          'Input layer does not contain zero weights, so apply CQAT instead.')
+    centroids_mask = None
     centroids, lookup = get_unique(weights)
+    num_centroids = tf.size(centroids)
 
-    # Prepare trainable variables for the Keras graph
-    clst_centroids_tf = layer.add_weight(
-        'cluster_centroids_tf',
-        shape=centroids.shape,
-        initializer=tf.keras.initializers.Constant(
-            value=K.batch_get_value([centroids])[0]),
-        dtype=centroids.dtype,
-        trainable=True)
+    if self.preserve_sparsity:
+      sparsity_mask = tf.math.divide_no_nan(weights, weights)
+      zero_idx = tf.argmin(tf.abs(centroids), axis=-1)
+      centroids_mask = 1.0 - tf.one_hot(zero_idx, num_centroids)
+      result = {SPARSITY_MASK: sparsity_mask}
 
-    ori_weights_tf = layer.add_weight(
-        'ori_weights_vars_tf',
-        shape=weights.shape,
-        initializer=tf.keras.initializers.Constant(
-            value=K.batch_get_value([weights])[0]),
-        dtype=weights.dtype,
-        trainable=True)
+    # Prepare clustering variables for the Keras graph when clusters
+    # exist, assuming we do not use number_of_clusters larger than 1024
+    if num_centroids > 1024:
+      return result
+    else:
+      clst_centroids_tf = layer.add_weight(
+          CLUSTER_CENTROIDS,
+          shape=centroids.shape,
+          initializer=tf.keras.initializers.Constant(
+              value=K.batch_get_value([centroids])[0]),
+          dtype=centroids.dtype,
+          trainable=True)
 
-    # Get clustering implementation according to layer type
-    clustering_impl_cls = (
-        clustering_registry.ClusteringLookupRegistry().get_clustering_impl(
-            layer.layer, name))
-    clustering_impl = clustering_impl_cls(clst_centroids_tf)
+      ori_weights_tf = layer.add_weight(
+          ORIGINAL_WEIGHTS,
+          shape=weights.shape,
+          initializer=tf.keras.initializers.Constant(
+              value=K.batch_get_value([weights])[0]),
+          dtype=weights.dtype,
+          trainable=True)
 
-    pulling_indices = tf.dtypes.cast(
-        clustering_impl.get_pulling_indices(ori_weights_tf),
-        lookup.dtype
-    )
+      # Get clustering implementation according to layer type
+      clustering_impl_cls = clustering_registry.ClusteringLookupRegistry(
+          ).get_clustering_impl(layer.layer, name)
+      clustering_impl = clustering_impl_cls(clst_centroids_tf)
 
-    pulling_indices_tf = layer.add_weight(
-        'pulling_indices_tf',
-        shape=lookup.shape,
-        initializer=tf.keras.initializers.Constant(
-            value=K.batch_get_value([pulling_indices])[0]),
-        dtype=lookup.dtype,
-        trainable=False)
+      pulling_indices = tf.dtypes.cast(
+          clustering_impl.get_pulling_indices(ori_weights_tf),
+          lookup.dtype
+      )
 
-    for v in layer.weights:
-      if 'kernel' in v.name:
-        kernel = v
+      pulling_indices_tf = layer.add_weight(
+          PULLING_INDICES,
+          shape=lookup.shape,
+          initializer=tf.keras.initializers.Constant(
+              value=K.batch_get_value([pulling_indices])[0]),
+          dtype=lookup.dtype,
+          trainable=False)
 
-    result = {
-        'cluster_centroids_tf': clst_centroids_tf,
-        'pulling_indices_tf': pulling_indices_tf,
-        'ori_weights_vars_tf': ori_weights_tf,
-        'weight_name': name,
-        'clst_impl': clustering_impl,
-        'set_kernel_weight': kernel,
-    }
-
-    return result
+      result_clst = {
+          CLUSTER_CENTROIDS: clst_centroids_tf,
+          PULLING_INDICES: pulling_indices_tf,
+          ORIGINAL_WEIGHTS: ori_weights_tf,
+          WEIGHT_NAME: name,
+          CLUSTERING_IMPL: clustering_impl,
+          CENTROIDS_MASK: centroids_mask,
+      }
+      result.update(result_clst)
+      return result
 
   def build(self, tensor_shape, name, layer):
-    """Extract centroids and indices to preserve weights clusters.
+    """ Build (P)CQAT wrapper when preserve_sparsity is true and the
+        input is clustered.
 
     Args:
       tensor_shape: Shape of weights which needs to be quantized.
       name: Name of weights in layer.
       layer: Quantization wrapped keras layer.
-
     Returns:
       Dictionary of centroids, indices and
       quantization params, the dictionary will be passed
@@ -366,6 +363,9 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
     """
     # To get all the initial values from pretrained clustered model
     result = self._build_clusters(name, layer)
+    # Result can have clustering nodes, then this is CQAT
+    # Result can have both clustering nodes and sparsity mask, then
+    # this will be PCQAT
     result.update(
         super(ClusterPreserveDefaultWeightsQuantizer,
               self).build(tensor_shape, name, layer))
@@ -382,27 +382,41 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
         quantize the tensor (layer's weights). This contains the weights
         created in the `build` function.
       **kwargs: Additional variables which may be passed to the quantizer.
-
     Returns:
       quantized tensor.
     """
-    # update associations
     if training:
-      weights['pulling_indices_tf'].assign(
-          tf.dtypes.cast(weights['clst_impl']
-                         .get_pulling_indices(weights['ori_weights_vars_tf']),
-                         weights['pulling_indices_tf'].dtype)
-      )
+      if CLUSTER_CENTROIDS in weights:
+        if self.preserve_sparsity:
+          weights[ORIGINAL_WEIGHTS].assign(
+              tf.multiply(weights[ORIGINAL_WEIGHTS],
+                          weights[SPARSITY_MASK]))
+          weights[CLUSTERING_IMPL].cluster_centroids.assign(
+              weights[CLUSTERING_IMPL].
+              cluster_centroids * weights[CENTROIDS_MASK]
+          )
+          weights[CLUSTER_CENTROIDS].assign(
+              weights[CLUSTERING_IMPL].cluster_centroids
+          )
+        # Insert clustering variables
+        weights[PULLING_INDICES].assign(tf.dtypes.cast(
+            weights[CLUSTERING_IMPL].get_pulling_indices(
+                weights[ORIGINAL_WEIGHTS]),
+            weights[PULLING_INDICES].dtype
+        ))
 
-      clustered_inputs = weights['clst_impl'].get_clustered_weight(
-          weights['pulling_indices_tf'], weights['ori_weights_vars_tf']
-      )
-      weights['set_kernel_weight'].assign(clustered_inputs)
+        output = weights[CLUSTERING_IMPL].get_clustered_weight(
+            weights[PULLING_INDICES], weights[ORIGINAL_WEIGHTS])
+        inputs.assign(output)
+      else:
+        if self.preserve_sparsity:
+          inputs = tf.multiply(inputs, weights[SPARSITY_MASK])
+        output = inputs
     else:
-      clustered_inputs = inputs
+      output = inputs
 
     return quant_ops.LastValueQuantize(
-        clustered_inputs,
+        output,
         weights['min_var'],
         weights['max_var'],
         is_training=training,
@@ -415,23 +429,24 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
 
 class ClusterPreserveDefault8BitWeightsQuantizer(
     ClusterPreserveDefaultWeightsQuantizer):
-  """ClusterPreserveWeightsQuantizer for default 8bit weights."""
-
-  def __init__(self):
+  """ClusterPreserveWeightsQuantizer for default 8bit weights"""
+  def __init__(self, preserve_sparsity):
     super(ClusterPreserveDefault8BitWeightsQuantizer,
           self).__init__(num_bits=8,
                          per_axis=False,
                          symmetric=True,
-                         narrow_range=True)
+                         narrow_range=True,
+                         preserve_sparsity=preserve_sparsity)
+    self.preserve_sparsity = preserve_sparsity
 
 
 class ClusterPreserveDefault8BitConvWeightsQuantizer(
     ClusterPreserveDefaultWeightsQuantizer,
     default_8bit_quantizers.Default8BitConvWeightsQuantizer):
-  """ClusterPreserveWeightsQuantizer for default 8bit Conv2D weights."""
-
-  def __init__(self):  # pylint:disable=super-init-not-called
+  """ClusterPreserveWeightsQuantizer for default 8bit Conv2D weights"""
+  def __init__(self, preserve_sparsity):
     default_8bit_quantizers.Default8BitConvWeightsQuantizer.__init__(self)
+    self.preserve_sparsity = preserve_sparsity
 
   def build(self, tensor_shape, name, layer):
     result = ClusterPreserveDefaultWeightsQuantizer._build_clusters(

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry_test.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry_test.py
@@ -35,8 +35,11 @@ class ClusterPreserveQuantizeRegistryTest(tf.test.TestCase,
 
   def setUp(self):
     super(ClusterPreserveQuantizeRegistryTest, self).setUp()
-    self.cluster_preserve_quantize_registry = (
-        cluster_preserve_quantize_registry.ClusterPreserveQuantizeRegistry())
+    # Test CQAT by default
+    self.cluster_preserve_quantize_registry = \
+      cluster_preserve_quantize_registry.ClusterPreserveQuantizeRegistry(
+          False
+      )
     # layers which are supported
     # initial and build a Conv2D layer
     self.layer_conv2d = layers.Conv2D(10, (2, 2))
@@ -54,15 +57,14 @@ class ClusterPreserveQuantizeRegistryTest(tf.test.TestCase,
     self.layer_custom.build()
 
   class CustomLayer(layers.Layer):
-    # a simple custom layer with training weights
-
+    """A simple custom layer with training weights."""
     def build(self, input_shape=(2, 2)):
       self.add_weight(shape=input_shape,
                       initializer='random_normal',
                       trainable=True)
 
   class CustomQuantizeConfig(QuantizeConfig):
-
+    """A dummy concrete class for testing unregistered configs."""
     def get_weights_and_quantizers(self, layer):
       return []
 
@@ -96,10 +98,11 @@ class ClusterPreserveQuantizeRegistryTest(tf.test.TestCase,
         self.cluster_preserve_quantize_registry.supports(self.layer_custom))
 
   def testApplyClusterPreserveWithQuantizeConfig(self):
-    self.cluster_preserve_quantize_registry.apply_cluster_preserve_quantize_config(
-        self.layer_conv2d,
-        default_8bit_quantize_registry.Default8BitConvQuantizeConfig(
-            ['kernel'], ['activation'], False))
+    self.cluster_preserve_quantize_registry.\
+      apply_cluster_preserve_quantize_config(
+          self.layer_conv2d,
+          default_8bit_quantize_registry.Default8BitConvQuantizeConfig(
+              ['kernel'], ['activation'], False))
 
   def testRaisesErrorUnsupportedQuantizeConfigWithLayer(self):
     with self.assertRaises(
@@ -116,14 +119,16 @@ class ClusterPreserveQuantizeRegistryTest(tf.test.TestCase,
 
 
 class ClusterPreserveDefault8bitQuantizeRegistryTest(tf.test.TestCase):
-
   def setUp(self):
     super(ClusterPreserveDefault8bitQuantizeRegistryTest, self).setUp()
     self.default_8bit_quantize_registry = (
         default_8bit_quantize_registry.Default8BitQuantizeRegistry())
     self.cluster_registry = clustering_registry.ClusteringRegistry()
-    self.cluster_preserve_quantize_registry = (
-        cluster_preserve_quantize_registry.ClusterPreserveQuantizeRegistry())
+    # Test CQAT by default
+    self.cluster_preserve_quantize_registry = \
+      cluster_preserve_quantize_registry.ClusterPreserveQuantizeRegistry(
+          False
+      )
 
   def testSupportsClusterDefault8bitQuantizeKerasLayers(self):
     # ClusterPreserveQuantize supported layer, must be suppoted

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/default_8bit_cluster_preserve_quantize_scheme.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/default_8bit_cluster_preserve_quantize_scheme.py
@@ -23,7 +23,14 @@ from tensorflow_model_optimization.python.core.quantization.keras.default_8bit i
 class Default8BitClusterPreserveQuantizeScheme(
     default_8bit_quantize_scheme.Default8BitQuantizeScheme):
   """Default 8 bit Cluster Preserve Quantization Scheme."""
+  def __init__(self, preserve_sparsity=True):
+    """This scheme does the same as Default8BitQuantizeScheme but it preserves
+    clusters and sparsity if the special flag is set.
+    Args:
+      preserve_sparsity: the flag to enable prune-cluster-preserving QAT.
+    """
+    self.preserve_sparsity = preserve_sparsity
 
   def get_quantize_registry(self):
-    return cluster_preserve_quantize_registry.\
-        Default8bitClusterPreserveQuantizeRegistry()
+    return (cluster_preserve_quantize_registry.
+            Default8bitClusterPreserveQuantizeRegistry(self.preserve_sparsity))

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/mnist_prune_cluster_preserve_qat_test.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/mnist_prune_cluster_preserve_qat_test.py
@@ -1,0 +1,394 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for a simple convnet with PCQAT on MNIST dataset. """
+import numpy as np
+import tensorflow as tf
+
+from tensorflow_model_optimization.python.core.clustering.keras.experimental import cluster as exp_tfmot_cluster
+from tensorflow_model_optimization.python.core.clustering.keras import cluster as tfmot_cluster
+from tensorflow_model_optimization.python.core.clustering.keras import cluster_config as tfmot_cluster_config
+
+from tensorflow_model_optimization.python.core.quantization.keras import quantize
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.cluster_preserve import (
+    default_8bit_cluster_preserve_quantize_scheme,)
+from tensorflow_model_optimization.python.core.sparsity.keras import prune
+from tensorflow_model_optimization.python.core.sparsity.keras import pruning_callbacks
+from tensorflow_model_optimization.python.core.sparsity.keras import pruning_schedule
+
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.cluster_preserve import cluster_utils
+
+
+layers = tf.keras.layers
+np.random.seed(1)
+tf.random.set_seed(3)
+
+
+def _build_model():
+  """Create the baseline model."""
+  i = tf.keras.layers.Input(shape=(28, 28), name='input')
+  x = tf.keras.layers.Reshape((28, 28, 1))(i)
+  x = tf.keras.layers.Conv2D(
+      filters=12, kernel_size=(3, 3), activation='relu', name='conv1')(x)
+  x = tf.keras.layers.MaxPool2D(2, 2)(x)
+  x = tf.keras.layers.Flatten()(x)
+  output = tf.keras.layers.Dense(10, name='fc2')(x)
+  model = tf.keras.Model(inputs=[i], outputs=[output])
+
+  return model
+
+
+def _get_dataset():
+  mnist = tf.keras.datasets.mnist
+  (x_train, y_train), (x_test, y_test) = mnist.load_data()
+  x_train, x_test = x_train / 255.0, x_test / 255.0
+  # Use subset of 60000 examples to keep unit test speed fast.
+  x_train = x_train[:1000]
+  y_train = y_train[:1000]
+
+  return (x_train, y_train), (x_test, y_test)
+
+
+def _train_model(model, callback_to_use, num_of_epochs):
+  loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+  model.compile(optimizer='adam',
+                loss=loss_fn,
+                metrics=['accuracy'],)
+  (x_train, y_train), _ = _get_dataset()
+  model.fit(
+      x_train,
+      y_train,
+      epochs=num_of_epochs,
+      callbacks=callback_to_use,
+      verbose=0)
+
+  return model
+
+
+def baseline_model():
+  """Build, compile and train the baseline model."""
+  base_model_epoch = 1
+  model = _build_model()
+  callbacks = []
+  model = _train_model(model, callbacks, base_model_epoch)
+
+  return model
+
+
+def _prune_model(original_model):
+  """ Apply the pruning wrapper, compile and train the model."""
+  prune_epoch = 1
+  pruning_params = {
+      'pruning_schedule':
+      pruning_schedule.ConstantSparsity(0.50, begin_step=0, frequency=10)
+  }
+  pruning_model = prune.prune_low_magnitude(original_model, **pruning_params)
+  callbacks = [pruning_callbacks.UpdatePruningStep()]
+  pruning_model = _train_model(pruning_model,
+                               callbacks,
+                               prune_epoch)
+  pruning_model_stripped = prune.strip_pruning(pruning_model)
+
+  return pruning_model, pruning_model_stripped
+
+
+def _cluster_model(original_model, sparsity_flag):
+  """ Apply the clustering wrapper, compile and train the model."""
+  cluster_epoch = 1
+  clustering_params = {
+      'number_of_clusters': 8,
+      'cluster_centroids_init':\
+      tfmot_cluster_config.CentroidInitialization.DENSITY_BASED,
+      'preserve_sparsity': sparsity_flag,
+  }
+  cluster_model = exp_tfmot_cluster.cluster_weights(
+      original_model, **clustering_params
+  )
+
+  callbacks = []
+  cluster_model = _train_model(cluster_model,
+                               callbacks,
+                               cluster_epoch)
+
+  clustered_model_stripped = tfmot_cluster.strip_clustering(cluster_model)
+
+  return cluster_model, clustered_model_stripped
+
+
+def selective_cluster_model(original_model, sparsity_flag):
+  cluster_epoch = 1
+  clustering_params = {
+      'number_of_clusters': 8,
+      'cluster_centroids_init':\
+      tfmot_cluster_config.CentroidInitialization.DENSITY_BASED,
+      'preserve_sparsity': sparsity_flag,
+  }
+
+  def apply_clustering_to_conv2d(layer):
+    if isinstance(layer, tf.keras.layers.Conv2D):
+      return exp_tfmot_cluster.cluster_weights(layer, **clustering_params)
+    return layer
+
+  cluster_model = tf.keras.models.clone_model(
+      original_model,
+      clone_function=apply_clustering_to_conv2d,
+  )
+
+  callbacks = []
+  cluster_model = _train_model(cluster_model,
+                               callbacks,
+                               cluster_epoch)
+
+  clustered_model_stripped = tfmot_cluster.strip_clustering(cluster_model)
+
+  return cluster_model, clustered_model_stripped
+
+
+def prune_cluster_preserve_quantize_model(clustered_model, preserve_sparsity):
+  """ Prune_cluster_preserve QAT model."""
+  pcqat_epoch = 1
+  quant_aware_annotate_model = \
+      quantize.quantize_annotate_model(clustered_model)
+  quant_aware_model = quantize.quantize_apply(
+      quant_aware_annotate_model,
+      scheme=default_8bit_cluster_preserve_quantize_scheme
+      .Default8BitClusterPreserveQuantizeScheme(preserve_sparsity))
+
+  callbacks = []
+  quant_aware_model = _train_model(quant_aware_model,
+                                   callbacks,
+                                   pcqat_epoch)
+  pcqat_stripped = cluster_utils.strip_clustering_cqat(quant_aware_model)
+
+  return quant_aware_model, pcqat_stripped
+
+
+def _get_num_unique_weights_kernel(model):
+  """ Check Dense and Conv2D layers."""
+  num_unique_weights_list = []
+  for layer in model.layers:
+    if isinstance(layer,
+                  (tf.keras.layers.Conv2D,
+                   tf.keras.layers.Dense,
+                   quantize.quantize_wrapper.QuantizeWrapper)):
+      for weights in layer.trainable_weights:
+        if 'kernel' in weights.name:
+          np_weights = tf.keras.backend.get_value(weights)
+          unique_weights = len(np.unique(np_weights))
+          num_unique_weights_list.append(unique_weights)
+
+  return num_unique_weights_list
+
+
+def _check_sparsity_kernel(model):
+  sparsity_list = []
+  for layer in model.layers:
+    if isinstance(layer,
+                  (prune.pruning_wrapper.PruneLowMagnitude,
+                   quantize.quantize_wrapper.QuantizeWrapper)):
+      for weights in layer.trainable_weights:
+        if 'kernel' in weights.name:
+          np_weights = tf.keras.backend.get_value(weights)
+          sparsity = 1.0 - np.count_nonzero(np_weights) / float(
+              np_weights.size)
+          sparsity_list.append(sparsity)
+
+  return sparsity_list
+
+
+# This code is directly from
+# https://www.tensorflow.org/model_optimization/guide/quantization/training_example
+def _evaluate_model(interpreter, test_images, test_labels):
+  input_index = interpreter.get_input_details()[0]['index']
+  output_index = interpreter.get_output_details()[0]['index']
+
+  # Run predictions on every image in the "test" dataset.
+  test_images = test_images[:300]
+  test_labels = test_labels[:300]
+
+  prediction_digits = []
+  for _, test_image in enumerate(test_images):
+    # Pre-processing: add batch dimension and convert to float32 to match with
+    # the model's input data format.
+    test_image = np.expand_dims(test_image, axis=0).astype(np.float32)
+    interpreter.set_tensor(input_index, test_image)
+    # Run inference.
+    interpreter.invoke()
+    # Post-processing: remove batch dimension and find the digit with highest
+    # probability.
+    output = interpreter.tensor(output_index)
+    digit = np.argmax(output()[0])
+    prediction_digits.append(digit)
+
+  # Compare prediction results with ground truth labels to calculate accuracy.
+  prediction_digits = np.array(prediction_digits)
+  accuracy = (prediction_digits == test_labels).mean()
+
+  return accuracy
+
+
+def _check_tflite_conversion(model, integer_only_quant):
+  # This function is for checking the tflite model conversion and accuracy of
+  # tflite evaluation.
+  (x_train, _), (x_test, y_test) = _get_dataset()
+  def representative_data_gen():
+    for input_value in tf.data.Dataset.from_tensor_slices(
+        x_train).batch(1).take(100):
+      yield [input_value]
+
+  if integer_only_quant:
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.representative_dataset = representative_data_gen
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    converter.inference_input_type = tf.uint8
+    converter.inference_output_type = tf.uint8
+    tflite_model_quant = converter.convert()
+  else:
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    tflite_model_quant = converter.convert()
+
+  interpreter = tf.lite.Interpreter(model_content=tflite_model_quant)
+  interpreter.allocate_tensors()
+  test_accuracy = _evaluate_model(interpreter, x_test, y_test)
+
+  return test_accuracy
+
+
+class FunctionalTest(tf.test.TestCase):
+  # The input of PCQAT is prune-preserving clustered
+  # model (full model clustered)
+  def testPCQATTrainingE2E(self):
+    # Baseline model training
+    model = baseline_model()
+
+    # Prune the model to have 50% sparsity
+    pruned_model, pruned_stripped = _prune_model(model)
+    sparsity_pruning = _check_sparsity_kernel(pruned_model)
+
+    # Cluster the model with 8 clusters
+    preserve_sparsity = True
+    clustered_model, clustered_model_stripped = _cluster_model(
+        pruned_stripped, preserve_sparsity)
+    _, (x_test, y_test) = _get_dataset()
+    pc_result = clustered_model.evaluate(x_test, y_test)
+    self.assertGreater(pc_result[1], 0.8)
+
+    # Case 1: apply PCQAT to the pruned_clustered_model with preserve_sparsity
+    # flag on
+    pcqat_model, pcqat_model_stripped = prune_cluster_preserve_quantize_model(
+        clustered_model_stripped, True)
+
+    # Evaluate the fp32 result of PCQAT
+    pcqat_result = pcqat_model.evaluate(x_test, y_test)
+    self.assertGreater(pcqat_result[1], 0.8)
+
+    # Check the unique weights of clustered_model and pcqat_model
+    num_of_unique_weights_clst = _get_num_unique_weights_kernel(
+        clustered_model_stripped)
+    num_of_unique_weights_pcqat = _get_num_unique_weights_kernel(
+        pcqat_model_stripped)
+    self.assertAllEqual(num_of_unique_weights_clst,
+                        num_of_unique_weights_pcqat)
+    # Check number of unique weights after clustering and pcqat should be
+    # less or equal to 8
+    # TODO: re-enable this check after PR #702 is merged
+    # self.assertAllLessEqual(num_of_unique_weights_clst, 8)
+
+    # Compare sparsity per layer for pruned_model and pcqat_model
+    sparsity_pcqat = _check_sparsity_kernel(pcqat_model)
+    # The sparsity in pcqat should be greater or euqal to the original
+    # uniform sparsity per layer. In this example, 0.5
+    self.assertAllGreaterEqual(np.array(sparsity_pcqat),
+                               sparsity_pruning[0])
+
+    # Verify the tflite conversion and accuracy
+    tflite_accuracy = _check_tflite_conversion(pcqat_model_stripped,
+                                               False)
+    self.assertGreater(tflite_accuracy, 0.8)
+
+    # Check the accuracy of PCQAT is not worse than the one of PC
+    self.assertGreaterEqual(pcqat_result[1], pc_result[1])
+
+    # Case 2: when the preserve_sparsity flag is False, the final sparsity
+    # of pcqat should be destroyed
+    pcqat_model, pcqat_model_stripped = prune_cluster_preserve_quantize_model(
+        clustered_model_stripped, False)
+    # Check unique weights
+    num_of_unique_weights_pcqat = _get_num_unique_weights_kernel(
+        pcqat_model_stripped)
+    self.assertAllEqual(num_of_unique_weights_clst,
+                        num_of_unique_weights_pcqat)
+
+    # Compare sparsity per layer for pruned_model and pcqat_model
+    sparsity_pcqat = _check_sparsity_kernel(pcqat_model)
+    # The sparsity in pcqat should be less than the original
+    # uniform sparsity per layer. In this example, 0.5
+    self.assertAllLess(np.array(sparsity_pcqat), sparsity_pruning[0])
+
+  def testPCQATSelectiveClustering(self):
+    # Baseline model training
+    model = baseline_model()
+
+    # Prune the model to have 50% sparsity
+    pruned_model, pruned_stripped = _prune_model(model)
+    sparsity_pruning = _check_sparsity_kernel(pruned_model)
+
+    # Cluster the conv2d layers with 8 clusters
+    preserve_sparsity = True
+    clustered_model, clustered_model_stripped = selective_cluster_model(
+        pruned_stripped, preserve_sparsity)
+    _, (x_test, y_test) = _get_dataset()
+    pc_result = clustered_model.evaluate(x_test, y_test)
+    self.assertGreater(pc_result[1], 0.8)
+
+    # Apply PCQAT on the pruned_clustered_model
+    pcqat_model, pcqat_model_stripped = prune_cluster_preserve_quantize_model(
+        clustered_model_stripped, True)
+
+    # Evaluate the fp32 result of PCQAT
+    pcqat_result = pcqat_model.evaluate(x_test, y_test)
+    self.assertGreater(pcqat_result[1], 0.8)
+
+    num_of_unique_weights_clst = _get_num_unique_weights_kernel(
+        clustered_model_stripped)
+    num_of_unique_weights_pcqat = _get_num_unique_weights_kernel(
+        pcqat_model_stripped)
+    # Selective clustering only applies to the conv2d layers,
+    # here we only check the first layer's unique weights
+    self.assertEqual(num_of_unique_weights_clst[0],
+                     num_of_unique_weights_pcqat[0])
+
+    # Check number of unique weights after clustering and pcqat should be
+    # both less or equal to 8
+    self.assertLessEqual(num_of_unique_weights_clst[0], 8)
+
+    # Check sparsity for the selected layer for pruned_model and pcqat_model
+    # to prove pcqat works on selective cases
+    sparsity_pcqat = _check_sparsity_kernel(pcqat_model)
+    self.assertGreaterEqual(sparsity_pcqat[0],
+                            sparsity_pruning[0])
+
+    # Check the tflite conversion for pcqat
+    pcqat_tflite_accuracy = _check_tflite_conversion(pcqat_model_stripped,
+                                                     False)
+    self.assertGreater(pcqat_tflite_accuracy, 0.8)
+
+    # Check the accuracy of PCQAT is not worse than the one of PC
+    self.assertGreaterEqual(pcqat_result[1], pc_result[1])
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
This PR adds support for Pruning-Clustering-preserving Quantization Aware Training (PCQAT). Aiming at preserving the sparsity and unique weights in the output optimized model, fixed pruning masks and the stochastic updates of clustering training variables are enabled during quantization-aware training.

User API:
```
  preserve_sparsity = True
  quant_aware_annotate_model = quantize.quantize_annotate_model(pruned_clustered_model)
  pcqat_model = quantize.quantize_apply(
      quant_aware_annotate_model,
      scheme=default_8bit_cluster_preserve_quantize_scheme
      .Default8BitClusterPreserveQuantizeScheme(preserve_sparsity))
```

Main changes:
- cluster_preserve_integration_test: edge cases (e.g. passing non-pruned models, passing models with uniform weights, etc.), checks for the updates of trainable variables between epochs
- mnist_prune_cluster_preserve_qat_test: minimal e2e mnist example to show benefits of PCQAT with the most common two types of configurations
- cluster_preserve_quantize_registry: main implementation of PCQAT algo.

Initial results (pruning sparsity: 50%, number of clusters: 8 (DS-CNN-L), 16 (Mobilenet_v1)):
| Model | Items | Baseline | Pruned Model | QATed | Pruned_Clustered Model | PCQATed Model | 
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| DS-CNN-L | FP32 Top1 Accuracy | 95.06% | 94.07% | (Fake INT8) 94.85% | **93.76%** | **(Fake INT8) 94.28%** |
|                        | INT8 full integer quantization | 94.35% | 93.80% | 94.82% | **93.21%** | **94.06%** |
|                        | INT8 .tflite gzip compression (bytes) | 506400 -> 425006 | 506400 -> 317937 | 507296 -> 424368 | 506400 -> 205333 | 507296 -> 201744 |
| Mobilenet_v1 (ImageNet) | FP32 Top1 Accuracy | 70.98% | 70.49% | (Fake INT8) 70.88% | **67.64%** | **(Fake INT8) 67.80%** |
|                        | INT8 full integer quantization | 70.37% | 69.85% | 70.87% | **66.89%** | **68.63%** |
|                        | INT8 .tflite gzip compression (bytes) | 4665552 -> 3886236 | 4665552 -> 2909148 | 4569416 -> 3808781| 4665552 -> 2013010 | 4569472 -> 1943957 |




