### PR TITLE
Fix for sparsity-preserving clustering

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/BUILD
+++ b/tensorflow_model_optimization/python/core/clustering/keras/BUILD
@@ -202,6 +202,7 @@ py_strict_test(
         # numpy dep1,
         # tensorflow dep1,
         "//tensorflow_model_optimization/python/core/keras:test_utils",
+        "//tensorflow_model_optimization/python/core/clustering/keras/experimental:cluster",
     ],
 )
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/BUILD
+++ b/tensorflow_model_optimization/python/core/clustering/keras/BUILD
@@ -229,5 +229,6 @@ py_strict_test(
         ":cluster",
         ":cluster_config",
         # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras/experimental",
     ],
 )

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -199,7 +199,7 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
         stripped_model_after_tuning, 0, 'kernel')
     # Check after sparsity-aware clustering, despite zero centroid can drift,
     # the final number of unique weights remains the same
-    self.assertEqual(nr_of_unique_weights_before, nr_of_unique_weights_after)
+    self.assertLessEqual(nr_of_unique_weights_after, nr_of_unique_weights_before)
     # Check that the null weights stayed the same before and after tuning.
     # There might be new weights that become zeros but sparsity-aware
     # clustering preserves the original null weights in the original positions

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -128,6 +128,14 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
     interpreter.invoke()
     interpreter.get_tensor(output_index)
 
+  @staticmethod
+  def _get_number_of_unique_weights(stripped_model, layer_nr, weight_name):
+    layer = stripped_model.layers[layer_nr]
+    weight = getattr(layer, weight_name)
+    weights_as_list = weight.numpy().flatten()
+    nr_of_unique_weights = len(set(weights_as_list))
+    return nr_of_unique_weights
+
   @keras_parameterized.run_all_keras_modes
   def testValuesRemainClusteredAfterTraining(self):
     """Verifies that training a clustered model does not destroy the clusters."""
@@ -150,73 +158,59 @@ class ClusterIntegrationTest(test.TestCase, parameterized.TestCase):
     unique_weights = set(weights_as_list)
     self.assertLessEqual(len(unique_weights), self.params["number_of_clusters"])
 
+
   @keras_parameterized.run_all_keras_modes
   def testSparsityIsPreservedDuringTraining(self):
-    # Set a specific random seed to ensure that we get some null weights to
-    # test sparsity preservation with.
+    """Set a specific random seed to ensure that we get some null weights
+    to test sparsity preservation with."""
     tf.random.set_seed(1)
-
-    # Verifies that training a clustered model does not destroy the sparsity of
-    # the weights.
+    # Verifies that training a clustered model with null weights in it
+    # does not destroy the sparsity of the weights.
     original_model = keras.Sequential([
         layers.Dense(5, input_shape=(5,)),
-        layers.Dense(5),
+        layers.Flatten(),
     ])
-
-    # Using a mininum number of centroids to make it more likely that some
-    # weights will be zero.
+    # Reset the kernel weights to reflect potential zero drifting of
+    # the cluster centroids
+    first_layer_weights = original_model.layers[0].get_weights()
+    first_layer_weights[0][:][0:2] = 0.0
+    first_layer_weights[0][:][3] = [-0.13, -0.08, -0.05, 0.005, 0.13]
+    first_layer_weights[0][:][4] = [-0.13, -0.08, -0.05, 0.005, 0.13]
+    original_model.layers[0].set_weights(first_layer_weights)
     clustering_params = {
-        "number_of_clusters": 3,
+        "number_of_clusters": 6,
         "cluster_centroids_init": CentroidInitialization.LINEAR,
         "preserve_sparsity": True
     }
-
     clustered_model = experimental_cluster.cluster_weights(
         original_model, **clustering_params)
-
     stripped_model_before_tuning = cluster.strip_clustering(clustered_model)
-    weights_before_tuning = stripped_model_before_tuning.layers[0].kernel
-    non_zero_weight_indices_before_tuning = np.nonzero(weights_before_tuning)
-
+    nr_of_unique_weights_before = self._get_number_of_unique_weights(
+        stripped_model_before_tuning, 0, 'kernel')
     clustered_model.compile(
         loss=keras.losses.categorical_crossentropy,
         optimizer="adam",
         metrics=["accuracy"],
     )
-    clustered_model.fit(x=self.dataset_generator2(), steps_per_epoch=1)
-
+    clustered_model.fit(x=self.dataset_generator(), steps_per_epoch=100)
     stripped_model_after_tuning = cluster.strip_clustering(clustered_model)
     weights_after_tuning = stripped_model_after_tuning.layers[0].kernel
-    non_zero_weight_indices_after_tuning = np.nonzero(weights_after_tuning)
-    weights_as_list_after_tuning = weights_after_tuning.numpy().reshape(
-        -1,).tolist()
-    unique_weights_after_tuning = set(weights_as_list_after_tuning)
-
+    nr_of_unique_weights_after = self._get_number_of_unique_weights(
+        stripped_model_after_tuning, 0, 'kernel')
+    # Check after sparsity-aware clustering, despite zero centroid can drift,
+    # the final number of unique weights remains the same
+    self.assertEqual(nr_of_unique_weights_before, nr_of_unique_weights_after)
     # Check that the null weights stayed the same before and after tuning.
+    # There might be new weights that become zeros but sparsity-aware
+    # clustering preserves the original null weights in the original positions
+    # of the weight array
     self.assertTrue(
-        np.array_equal(non_zero_weight_indices_before_tuning,
-                       non_zero_weight_indices_after_tuning))
-
+        np.array_equal(first_layer_weights[0][:][0:2],
+                       weights_after_tuning[:][0:2]))
     # Check that the number of unique weights matches the number of clusters.
     self.assertLessEqual(
-        len(unique_weights_after_tuning), self.params["number_of_clusters"])
-
-  @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
-  def testEndToEndSequential(self):
-    """Test End to End clustering - sequential model."""
-    original_model = keras.Sequential([
-        layers.Dense(5, input_shape=(5,)),
-        layers.Dense(5),
-    ])
-
-    def clusters_check(stripped_model):
-      # dense layer
-      weights_as_list = stripped_model.get_weights()[0].reshape(-1,).tolist()
-      unique_weights = set(weights_as_list)
-      self.assertLessEqual(
-          len(unique_weights), self.params["number_of_clusters"])
-
-    self.end_to_end_testing(original_model, clusters_check)
+        nr_of_unique_weights_after,
+        clustering_params["number_of_clusters"])
 
   @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
   def testEndToEndFunctional(self):

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -107,9 +107,9 @@ class ClusterWeights(Wrapper):
 
     # Stores the pairs of weight names and their respective sparsity masks
     self.sparsity_masks = {}
-    self.zero_idx = {}
 
     # Stores the pairs of weight names and the zero centroids
+    self.zero_idx = {}
 
     # Map weight names to original clusterable weights variables
     # Those weights will still be updated during backpropagation

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -215,6 +215,10 @@ class ClusterWeights(Wrapper):
               pulling_indices, original_weight))
 
       if self.preserve_sparsity:
+        # Re-discover the sparsity masks to avoid drifting
+        self.sparsity_masks[weight_name] = (
+            tf.cast(tf.math.not_equal(clustered_weights, 0), dtype=tf.float32)
+        )
         # Apply the sparsity mask to the clustered weights
         clustered_weights = tf.math.multiply(clustered_weights,
                                              self.sparsity_masks[weight_name])

--- a/tensorflow_model_optimization/python/core/clustering/keras/mnist_clustering_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/mnist_clustering_test.py
@@ -14,10 +14,12 @@
 # ==============================================================================
 """Tests for a simple convnet with clusterable layer on the MNIST dataset."""
 
+from absl.testing import parameterized
 import tensorflow as tf
 
 from tensorflow_model_optimization.python.core.clustering.keras import cluster
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
+from tensorflow_model_optimization.python.core.clustering.keras.experimental import cluster as experimental_cluster
 
 tf.random.set_seed(42)
 
@@ -63,7 +65,7 @@ def _train_model(model):
   model.fit(x_train, y_train, epochs=EPOCHS)
 
 
-def _cluster_model(model, number_of_clusters):
+def _cluster_model(model, number_of_clusters, preserve_sparsity=False):
 
   (x_train, y_train), _ = _get_dataset()
 
@@ -71,11 +73,13 @@ def _cluster_model(model, number_of_clusters):
       'number_of_clusters':
           number_of_clusters,
       'cluster_centroids_init':
-          cluster_config.CentroidInitialization.KMEANS_PLUS_PLUS
+          cluster_config.CentroidInitialization.KMEANS_PLUS_PLUS,
+      'preserve_sparsity':
+          preserve_sparsity,
   }
 
   # Cluster model
-  clustered_model = cluster.cluster_weights(model, **clustering_params)
+  clustered_model = experimental_cluster.cluster_weights(model, **clustering_params)
 
   # Use smaller learning rate for fine-tuning
   # clustered model
@@ -106,13 +110,27 @@ def _get_number_of_unique_weights(stripped_model, layer_nr, weight_name):
 
   return nr_of_unique_weights
 
+def _deepcopy_model(model):
+  model_copy = keras.models.clone_model(model)
+  model_copy.set_weights(model.get_weights())
+  return model_copy
 
-class FunctionalTest(tf.test.TestCase):
+class FunctionalTest(tf.test.TestCase, parameterized.TestCase):
 
-  def testMnist(self):
-    """In this test we test that 'kernel' weights are clustered."""
+  def setUp(self):
     model = _build_model()
     _train_model(model)
+    self.model = model
+    self.dataset = _get_dataset()
+
+  @parameterized.parameters(
+      (False),
+      (True),
+  )
+  def testMnist(self, preserve_sparisty):
+    """In this test we test that 'kernel' weights are clustered."""
+    model = self.model
+    _, (x_test, y_test) = self.dataset
 
     # Checks that number of original weights('kernel') is greater than the
     # number of clusters
@@ -123,12 +141,11 @@ class FunctionalTest(tf.test.TestCase):
     nr_of_bias_weights = _get_number_of_unique_weights(model, -1, 'bias')
     self.assertGreater(nr_of_bias_weights, NUMBER_OF_CLUSTERS)
 
-    _, (x_test, y_test) = _get_dataset()
-
     results_original = model.evaluate(x_test, y_test)
     self.assertGreater(results_original[1], 0.8)
 
-    clustered_model = _cluster_model(model, NUMBER_OF_CLUSTERS)
+    model_copy = _deepcopy_model(model)
+    clustered_model = _cluster_model(model_copy, NUMBER_OF_CLUSTERS, preserve_sparisty)
 
     results = clustered_model.evaluate(x_test, y_test)
 


### PR DESCRIPTION
* small fix to stop centroids from drifting
* unit test coverage for fix

Summary of change:
Ensure the sparsity mask is updated during training time in sparsity-preserving clustering. Due to cluster-weight associations updates, the location of zero weights may change during training. This patch updated the sparsity mask according to such changes. It also adds extra tests to ensure sparsity aware clustering works during distributed training.