### PR TITLE
[PQAT] add prune preserve callback.

### DIFF
--- a/tensorflow_model_optimization/python/core/api/BUILD
+++ b/tensorflow_model_optimization/python/core/api/BUILD
@@ -41,6 +41,7 @@ py_strict_library(
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve:cluster_utils",
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve:default_8bit_cluster_preserve_quantize_scheme",
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve:default_8bit_prune_preserve_quantize_scheme",
+        "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve:prune_preserve_callbacks",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_layout_transform",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_registry",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_scheme",

--- a/tensorflow_model_optimization/python/core/api/experimental/combine/__init__.py
+++ b/tensorflow_model_optimization/python/core/api/experimental/combine/__init__.py
@@ -22,4 +22,6 @@ from tensorflow_model_optimization.python.core.quantization.keras.collaborative_
 
 from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.prune_preserve.default_8bit_prune_preserve_quantize_scheme import (
     Default8BitPrunePreserveQuantizeScheme,)
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.prune_preserve.prune_preserve_callbacks import (
+    PrunePreserve,)
 

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/BUILD
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/BUILD
@@ -14,6 +14,7 @@ py_strict_library(
     srcs_version = "PY3",
     deps = [
         ":default_8bit_prune_preserve_quantize_scheme",  # buildcleaner: keep
+        ":prune_preserve_callbacks",
     ],
 )
 
@@ -58,5 +59,16 @@ py_strict_library(
     deps = [
         ":prune_preserve_quantize_registry",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_scheme",
+    ],
+)
+
+py_strict_library(
+    name = "prune_preserve_callbacks",
+    srcs = [
+        "prune_preserve_callbacks.py",
+    ],
+    srcs_version = "PY3",
+    deps = [
+        # tensorflow dep1,
     ],
 )

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_callbacks.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_callbacks.py
@@ -1,0 +1,52 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Keras callbacks for preserving sparsity in weights."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+
+class PrunePreserve(tf.keras.callbacks.Callback):
+  """Keras callback for PQAT, which preserves sparsity in weights.
+
+  This callback must be used when optimizing the model with PQAT, it ensures
+  sparsity of weights are preserved after the final backpropagation.
+
+  Example:
+
+  ```python
+  quant_aware_model = tfmot.quantization.keras.quantize_apply(
+      quant_aware_annotate_model,
+      scheme=tfmot.experimental.combine.Default8BitPrunePreserveQuantizeScheme())
+  quant_aware_model.fit(x, y,
+      callbacks=[tfmot.experimental.combine.PrunePreserve()])
+  ```
+  """
+
+  def __init__(self):
+    super(PrunePreserve, self).__init__()
+
+  def on_epoch_end(self, batch, logs=None):
+    # At the end of every epoch, reapply sparsity masks. This ensures that when
+    # the model is saved after completion, the sparsity of weights are preserved.
+    for layer in self.model.layers:
+      if hasattr(layer, 'prune_preserve_vars'):
+        masked_weights = tf.multiply(
+            layer.prune_preserve_vars['weights'],
+            layer.prune_preserve_vars['sparsity_mask'])
+        layer.prune_preserve_vars['weights'].assign(masked_weights)

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_quantize_registry.py
@@ -255,6 +255,8 @@ class PrunePreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
   def _build_sparsity_mask(self, name, layer):
     weights = getattr(layer.layer, name)
     sparsity_mask = tf.math.divide_no_nan(weights, weights)
+    layer.prune_preserve_vars = {
+        'weights': weights, 'sparsity_mask': sparsity_mask}
 
     return {'sparsity_mask': sparsity_mask}
 

--- a/tensorflow_model_optimization/python/examples/quantization_with_sparsity/keras/BUILD
+++ b/tensorflow_model_optimization/python/examples/quantization_with_sparsity/keras/BUILD
@@ -14,6 +14,7 @@ py_strict_binary(
         # tensorflow dep1,
         "//tensorflow_model_optimization/python/core/quantization/keras:quantize",
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve:default_8bit_prune_preserve_quantize_scheme",
+        "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve:prune_preserve_callbacks",
         "//tensorflow_model_optimization/python/core/sparsity/keras:prune",
         "//tensorflow_model_optimization/python/core/sparsity/keras:pruning_callbacks",
         "//tensorflow_model_optimization/python/core/sparsity/keras:pruning_schedule",

--- a/tensorflow_model_optimization/python/examples/quantization_with_sparsity/keras/mnist_cnn.py
+++ b/tensorflow_model_optimization/python/examples/quantization_with_sparsity/keras/mnist_cnn.py
@@ -27,6 +27,8 @@ import tensorflow as tf
 from tensorflow_model_optimization.python.core.quantization.keras import quantize
 from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.prune_preserve import (
     default_8bit_prune_preserve_quantize_scheme,)
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.prune_preserve import (
+    prune_preserve_callbacks,)
 from tensorflow_model_optimization.python.core.sparsity.keras import prune
 from tensorflow_model_optimization.python.core.sparsity.keras import pruning_callbacks
 from tensorflow_model_optimization.python.core.sparsity.keras import pruning_schedule
@@ -130,9 +132,11 @@ def prune_preserve_quantize_model(pruned_model, train_images, train_labels):
       .Default8BitPrunePreserveQuantizeScheme())
   quant_aware_model.summary()
 
+  callbacks = [prune_preserve_callbacks.PrunePreserve()]
   fit_kwargs = {
       'batch_size': batch_size,
       'epochs': epochs,
+      'callbacks': callbacks,
   }
   compile_and_fit(quant_aware_model,
                   train_images,


### PR DESCRIPTION
This is a fix of PQAT issue: pruned zero weights drift away after final propagation.

Add callback, apply sparsity mask on weights at the end of every epoch.

TODO:
unit test

Resolving same issue as: https://github.com/tensorflow/model-optimization/pull/721