### PR TITLE
[PQAT] apply sparsity mask on weights gradient

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/BUILD
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/BUILD
@@ -29,6 +29,7 @@ py_strict_library(
         "//tensorflow_model_optimization/python/core/quantization/keras:quantizers",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_registry",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantizers",
+        "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve:prune_preserve_utils",
     ],
 )
 
@@ -58,5 +59,17 @@ py_strict_library(
     deps = [
         ":prune_preserve_quantize_registry",
         "//tensorflow_model_optimization/python/core/quantization/keras/default_8bit:default_8bit_quantize_scheme",
+    ],
+)
+
+py_strict_library(
+    name = "prune_preserve_utils",
+    srcs = [
+        "prune_preserve_utils.py",
+    ],
+    srcs_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        # tensorflow dep1,
     ],
 )

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_quantize_registry.py
@@ -22,6 +22,8 @@ from tensorflow_model_optimization.python.core.quantization.keras.default_8bit i
     default_8bit_quantize_registry,)
 from tensorflow_model_optimization.python.core.quantization.keras.default_8bit import (
     default_8bit_quantizers,)
+from tensorflow_model_optimization.python.core.quantization.keras.collaborative_optimizations.prune_preserve import (
+    prune_preserve_utils,)
 
 layers = tf.keras.layers
 
@@ -292,7 +294,8 @@ class PrunePreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
       quantized tensor.
     """
 
-    prune_preserve_inputs = tf.multiply(inputs, weights['sparsity_mask'])
+    prune_preserve_inputs = prune_preserve_utils.apply_sparsity_mask_to_weights_gradient(
+        inputs, weights['sparsity_mask'])
 
     return quant_ops.LastValueQuantize(
         prune_preserve_inputs,

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_utils.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve/prune_preserve_utils.py
@@ -1,0 +1,26 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Util functions for PQAT"""
+
+import tensorflow as tf
+
+
+@tf.custom_gradient
+def apply_sparsity_mask_to_weights_gradient(weights, sparsity_mask):
+    # Here zero-out the weights gradient with sparsity mask,
+    # it ensure sparsity of weights are preserved with PQAT
+    def grad(weights_gradient):
+        return tf.multiply(weights_gradient, sparsity_mask), None
+    return weights, grad


### PR DESCRIPTION
This is a fix of PQAT issue: pruned zero weights drift away after final propagation.

Apply sparsity mask on gradient of weights.

TODO:
unit test

Resolving same issue as: https://github.com/tensorflow/model-optimization/pull/720