### PR TITLE
remove tensorflow uninstall and tf-nightly

### DIFF
--- a/tensorflow_model_optimization/g3doc/guide/quantization/training_example.ipynb
+++ b/tensorflow_model_optimization/g3doc/guide/quantization/training_example.ipynb
@@ -108,8 +108,6 @@
       },
       "outputs": [],
       "source": [
-        "! pip uninstall -y tensorflow\n",
-        "! pip install -q tf-nightly\n",
         "! pip install -q tensorflow-model-optimization\n"
       ]
     },


### PR DESCRIPTION
Google Colab no longer requires the TF nightly build, which is causing errors.  Using the installed TF is sufficient