### PR TITLE
[Clustering] Add the layer support for StackedRNNCells, PeepholeLSTMCell, and Bidirectional.

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster.py
@@ -236,7 +236,8 @@ def _cluster_weights(to_cluster, number_of_clusters, cluster_centroids_init,
       return layer
     if isinstance(layer, InputLayer):
       return layer.__class__.from_config(layer.get_config())
-    if isinstance(layer, tf.keras.layers.RNN):
+    if isinstance(layer, tf.keras.layers.RNN) or isinstance(
+        layer, tf.keras.layers.Bidirectional):
       return cluster_wrapper.ClusterWeightsRNN(
           layer,
           number_of_clusters,

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -375,7 +375,7 @@ class ClusterRNNIntegrationTest(tf.test.TestCase, parameterized.TestCase):
 
     return stripped_model
 
-  def __assertNbUniqueWeights(self, weight, expected_unique_weights):
+  def _assertNbUniqueWeights(self, weight, expected_unique_weights):
     nr_unique_weights = len(np.unique(weight.numpy().flatten()))
     assert nr_unique_weights == expected_unique_weights
 
@@ -391,11 +391,11 @@ class ClusterRNNIntegrationTest(tf.test.TestCase, parameterized.TestCase):
 
     stripped_model = self._clusterTrainStrip(model)
 
-    self.__assertNbUniqueWeights(
+    self._assertNbUniqueWeights(
         weight=stripped_model.layers[1].cell.kernel,
         expected_unique_weights=self.params_clustering["number_of_clusters"],
     )
-    self.__assertNbUniqueWeights(
+    self._assertNbUniqueWeights(
         weight=stripped_model.layers[1].cell.recurrent_kernel,
         expected_unique_weights=self.params_clustering["number_of_clusters"],
     )
@@ -414,11 +414,11 @@ class ClusterRNNIntegrationTest(tf.test.TestCase, parameterized.TestCase):
 
     stripped_model = self._clusterTrainStrip(model)
 
-    self.__assertNbUniqueWeights(
+    self._assertNbUniqueWeights(
         weight=stripped_model.layers[1].cell.kernel,
         expected_unique_weights=self.params_clustering["number_of_clusters"],
     )
-    self.__assertNbUniqueWeights(
+    self._assertNbUniqueWeights(
         weight=stripped_model.layers[1].cell.recurrent_kernel,
         expected_unique_weights=self.params_clustering["number_of_clusters"],
     )
@@ -437,11 +437,11 @@ class ClusterRNNIntegrationTest(tf.test.TestCase, parameterized.TestCase):
 
     stripped_model = self._clusterTrainStrip(model)
 
-    self.__assertNbUniqueWeights(
+    self._assertNbUniqueWeights(
         weight=stripped_model.layers[1].cell.kernel,
         expected_unique_weights=self.params_clustering["number_of_clusters"],
     )
-    self.__assertNbUniqueWeights(
+    self._assertNbUniqueWeights(
         weight=stripped_model.layers[1].cell.recurrent_kernel,
         expected_unique_weights=self.params_clustering["number_of_clusters"],
     )
@@ -451,48 +451,77 @@ class ClusterRNNIntegrationTest(tf.test.TestCase, parameterized.TestCase):
   @keras_parameterized.run_all_keras_modes
   def testClusterPeepholeLSTM(self):
     model = keras.models.Sequential()
-    model.add(keras.layers.Embedding(self.max_features, 16,
-                                     input_length=self.maxlen))
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
     model.add(keras.layers.RNN(tf.keras.experimental.PeepholeLSTMCell(16)))
     model.add(keras.layers.Dense(1))
     model.add(keras.layers.Activation("sigmoid"))
 
-    # PeepholeLSTM not supported yet.
-    with self.assertRaises(ValueError):
-      self._clusterTrainStrip(model)
+    self._clusterTrainStrip(model)
+
+    self._assertNbUniqueWeights(
+      weight=model.layers[1].cell.kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self._assertNbUniqueWeights(
+      weight=model.layers[1].cell.recurrent_kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self._assertNbUniqueWeights(
+      weight=model.layers[0].embeddings,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
 
   @keras_parameterized.run_all_keras_modes
   def testClusterBidirectional(self):
     model = keras.models.Sequential()
-    model.add(keras.layers.Embedding(self.max_features, 16,
-                                     input_length=self.maxlen))
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
     model.add(keras.layers.Bidirectional(keras.layers.SimpleRNN(16)))
     model.add(keras.layers.Dense(1))
     model.add(keras.layers.Activation("sigmoid"))
 
-    # Bidirectional not supported yet.
-    with self.assertRaises(ValueError):
-      self._clusterTrainStrip(model)
+    self._clusterTrainStrip(model)
+
+    self._assertNbUniqueWeights(
+      weight=model.layers[1].forward_layer.cell.kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self._assertNbUniqueWeights(
+      weight=model.layers[1].forward_layer.cell.recurrent_kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self._assertNbUniqueWeights(
+      weight=model.layers[0].embeddings,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
 
   @keras_parameterized.run_all_keras_modes
   def testClusterStackedRNNCells(self):
     model = keras.models.Sequential()
-    model.add(keras.layers.Embedding(self.max_features, 16,
-                                     input_length=self.maxlen))
+    model.add(keras.layers.Embedding(self.max_features, 16, input_length=self.maxlen))
     model.add(
-        tf.keras.layers.RNN(
-            tf.keras.layers.StackedRNNCells(
-                [keras.layers.SimpleRNNCell(16) for _ in range(2)]
-            )
+      tf.keras.layers.RNN(
+        tf.keras.layers.StackedRNNCells(
+          [keras.layers.SimpleRNNCell(16) for _ in range(2)]
         )
+      )
     )
     model.add(keras.layers.Dense(1))
     model.add(keras.layers.Activation("sigmoid"))
 
-    # StackedRNNCells not supported yet.
-    with self.assertRaises(ValueError):
-      self._clusterTrainStrip(model)
+    self._clusterTrainStrip(model)
 
+    self._assertNbUniqueWeights(
+      weight=model.layers[1].cell.cells[0].kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self._assertNbUniqueWeights(
+      weight=model.layers[1].cell.cells[0].recurrent_kernel,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
+    self._assertNbUniqueWeights(
+      weight=model.layers[0].embeddings,
+      expected_unique_weights=self.params_clustering["number_of_clusters"],
+    )
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -30,7 +30,7 @@ GradientAggregation = cluster_config.GradientAggregation
 
 
 class ClusterWeights(Wrapper):
-  """This wrapper augments a keras layer so that the weight tensor(s) can be clustered.
+  """This wrapper augments a layer so the weight tensor(s) can be clustered.
 
   This wrapper implements nearest neighbor clustering algorithm. This algorithm
   ensures that only a specified number of unique values are used in a weight
@@ -156,10 +156,15 @@ class ClusterWeights(Wrapper):
       # Store the original weight in this wrapper
       # The child reference will be overridden in
       # update_clustered_weights_associations
+      # The actual weight_name here for the clustering wrapper is not
+      # necessarily the same as the original one from the layer wrapped.
+      # For example for cells in StackedRNNCell, the names become
+      # 'kernel/0', 'recurrent_kernel/0', 'kernel/1', 'recurrent_kernel/1'
       original_weight = self.get_weight_from_layer(weight_name)
       self.original_clusterable_weights[weight_name] = original_weight
+      # Track the variable
       setattr(self, 'original_weight_' + weight_name,
-              original_weight)  # Track the variable
+              original_weight)
       # Store the position in layer.weights of original_weight to restore during
       # stripping
       position_original_weight = next(
@@ -180,9 +185,18 @@ class ClusterWeights(Wrapper):
           initializer=tf.keras.initializers.Constant(value=cluster_centroids))
 
       # Init the weight clustering algorithm
+      if isinstance(self.layer, tf.keras.layers.RNN):
+        if isinstance(self.layer.cell, tf.keras.layers.StackedRNNCells):
+          weight_name_no_index = weight_name.split('/')[0]
+        else:
+          weight_name_no_index = weight_name
+      elif isinstance(self.layer, tf.keras.layers.Bidirectional):
+        weight_name_no_index = weight_name.split('/')[0]
+      else:
+        weight_name_no_index = weight_name
       self.clustering_algorithms[weight_name] = (
           clustering_registry.ClusteringLookupRegistry().get_clustering_impl(
-              self.layer, weight_name)
+              self.layer, weight_name_no_index)
           (
               clusters_centroids=self.cluster_centroids[weight_name],
               cluster_gradient_aggregation=self.cluster_gradient_aggregation,
@@ -190,7 +204,8 @@ class ClusterWeights(Wrapper):
 
       # Init the pulling_indices (weights associations)
       pulling_indices = (
-          self.clustering_algorithms[weight_name].get_pulling_indices(weight))
+          self.clustering_algorithms[weight_name].get_pulling_indices(
+              weight))
       self.pulling_indices[weight_name] = self.add_weight(
           '{}{}'.format('pulling_indices_', weight_name),
           shape=pulling_indices.shape,
@@ -246,7 +261,10 @@ class ClusterWeights(Wrapper):
               pulling_indices, original_weight))
 
       # Replace the weights with their clustered counterparts
-      self.set_weight_to_layer(weight_name, clustered_weights)
+      # Remove weight_name index so the wrapper layer weight_name can match
+      # the original one
+      self.set_weight_to_layer(weight_name,
+                               clustered_weights)
 
   def call(self, inputs, training=None, **kwargs):
     # Update cluster associations in order to set the latest weights
@@ -321,10 +339,50 @@ class ClusterWeights(Wrapper):
 
 
 class ClusterWeightsRNN(ClusterWeights):
-  """This wrapper augments a keras RNN layer so that the weights can be clustered."""
+  """This wrapper augments a RNN layer so that the weights can be clustered.
+
+  The weight_name of a single cell in RNN layers is marked with an index in
+  registry. In the wrapper layer, the index needs to be removed for matching
+  the attribute of the cell layer."""
+  def get_weight_name_without_index(self, weight_name):
+    weight_name_with_index = weight_name.split('/')
+    return weight_name_with_index[0], int(weight_name_with_index[1])
+
+  def get_return_layer_cell(self, index):
+    return_layer_cell =  (self.layer.forward_layer.cell if index == 0 else
+                          self.layer.backward_layer.cell)
+    return return_layer_cell
 
   def get_weight_from_layer(self, weight_name):
-    return getattr(self.layer.cell, weight_name)
+    weight_name_no_index, i = self.get_weight_name_without_index(weight_name)
+    if hasattr(self.layer, 'cell'):
+      if isinstance(self.layer.cell, tf.keras.layers.StackedRNNCells):
+        return getattr(self.layer.cell.cells[i], weight_name_no_index)
+      else:
+        return getattr(self.layer.cell, weight_name_no_index)
+    elif isinstance(self.layer, tf.keras.layers.Bidirectional):
+      if i < 0 or i > 1:
+        raise ValueError(
+            'Unsupported number of cells in the layer to get weights from.')
+      return_layer_cell =  self.get_return_layer_cell(i)
+      return getattr(return_layer_cell, weight_name_no_index)
+    else:
+      raise ValueError('No cells in the RNN layer to get weights from.')
 
   def set_weight_to_layer(self, weight_name, new_weight):
-    setattr(self.layer.cell, weight_name, new_weight)
+    weight_name_no_index, i = self.get_weight_name_without_index(weight_name)
+    if hasattr(self.layer, 'cell'):
+      if isinstance(self.layer.cell, tf.keras.layers.StackedRNNCells):
+        return setattr(self.layer.cell.cells[i],
+                       weight_name_no_index,
+                       new_weight)
+      else:
+        return setattr(self.layer.cell, weight_name_no_index, new_weight)
+    elif isinstance(self.layer, tf.keras.layers.Bidirectional):
+      if i < 0 or i > 1:
+        raise ValueError(
+            'Unsupported number of cells in the layer to set weights for.')
+      return_layer_cell =  self.get_return_layer_cell(i)
+      return setattr(return_layer_cell, weight_name_no_index, new_weight)
+    else:
+      raise ValueError('No cells in the RNN layer to set weights for.')

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/BUILD
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/BUILD
@@ -16,8 +16,6 @@ py_binary(
     ],
     python_version = "PY3",
     deps = [
-        # numpy dep1,
-        # tensorflow dep1,
         "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
         "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
     ],
@@ -30,8 +28,6 @@ py_binary(
     ],
     python_version = "PY3",
     deps = [
-        # numpy dep1,
-        # tensorflow dep1,
         "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
         "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
     ],
@@ -44,8 +40,31 @@ py_binary(
     ],
     python_version = "PY3",
     deps = [
-        # numpy dep1,
-        # tensorflow dep1,
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
+    ],
+)
+
+py_strict_library(
+    name = "imdb_utils",
+    srcs = [
+        "imdb_utils.py",
+    ],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
+        "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
+    ],
+)
+
+py_binary(
+    name = "imdb_multiple_cells",
+    srcs = [
+        "imdb_multiple_cells.py",
+    ],
+    python_version = "PY3",
+    deps = [
+        ":imdb_utils",
         "//tensorflow_model_optimization/python/core/clustering/keras:cluster",
         "//tensorflow_model_optimization/python/core/clustering/keras:cluster_config",
     ],

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_multiple_cells.py
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_multiple_cells.py
@@ -1,0 +1,79 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""End-to-end tests for StackedRNNCells and PeepholeLSTMCell.
+
+The dataset is actually too small for LSTM to be of any advantage
+compared to simpler, much faster methods such as TF-IDF+LogReg.
+"""
+
+from __future__ import print_function
+
+import tensorflow.keras as keras
+import tensorflow.keras.preprocessing.sequence as sequence
+from tensorflow_model_optimization.python.core.clustering.keras import cluster
+from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
+from imdb_utils import prepare_dataset, cluster_train_eval_strip
+
+
+max_features = 20000
+maxlen = 100  # cut texts after this number of words
+batch_size = 32
+
+x_train, y_train, x_test, y_test = prepare_dataset()
+
+print("Build a model with the StackedRNNCells with PeepholeLSTMCell...")
+model = keras.models.Sequential()
+
+model.add(keras.layers.Embedding(max_features, 128, input_length=maxlen))
+model.add(
+    keras.layers.RNN(
+        keras.layers.StackedRNNCells(
+            [keras.experimental.PeepholeLSTMCell(128) for _ in range(2)])))
+model.add(keras.layers.Dropout(0.5))
+model.add(keras.layers.Dense(1))
+model.add(keras.layers.Activation("sigmoid"))
+
+test_case = "StackedRNNCells_PeepholeLSTMCell"
+cluster_train_eval_strip(
+    model,x_train, y_train, x_test, y_test, batch_size, test_case)
+
+print("Build a model with the StackedRNNCells with LSTMCell...")
+model = keras.models.Sequential()
+
+model.add(keras.layers.Embedding(max_features, 128, input_length=maxlen))
+model.add(
+    keras.layers.RNN(
+        keras.layers.StackedRNNCells(
+            [keras.layers.LSTMCell(128) for _ in range(2)])))
+model.add(keras.layers.Dropout(0.5))
+model.add(keras.layers.Dense(1))
+model.add(keras.layers.Activation("sigmoid"))
+
+test_case = "StackedRNNCells_LSTMCell"
+cluster_train_eval_strip(
+    model, x_train, y_train, x_test, y_test, batch_size, test_case)
+
+print("Build a model with the Bidirectional wrapper with LSTM layer...")
+model = keras.models.Sequential()
+
+model.add(keras.layers.Embedding(max_features, 128, input_length=maxlen))
+model.add(keras.layers.Bidirectional(keras.layers.LSTM(128)))
+model.add(keras.layers.Dropout(0.5))
+model.add(keras.layers.Dense(1))
+model.add(keras.layers.Activation("sigmoid"))
+
+test_case = "Bidirectional_LSTM"
+cluster_train_eval_strip(
+    model, x_train, y_train, x_test, y_test, batch_size, test_case)

--- a/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_utils.py
+++ b/tensorflow_model_optimization/python/examples/clustering/keras/imdb/imdb_utils.py
@@ -1,0 +1,75 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common utils for testing RNN e2e tests.
+
+The dataset is actually too small for LSTM to be of any advantage
+compared to simpler, much faster methods such as TF-IDF+LogReg.
+"""
+from __future__ import print_function
+
+import tensorflow.keras as keras
+import tensorflow.keras.preprocessing.sequence as sequence
+from tensorflow_model_optimization.python.core.clustering.keras import cluster
+from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
+
+
+def prepare_dataset():
+  max_features = 20000
+  maxlen = 100  # cut texts after this number of words
+
+  print("Loading data...")
+  (x_train,
+  y_train), (x_test,
+             y_test) = keras.datasets.imdb.load_data(num_words=max_features)
+  print(len(x_train), "train sequences")
+  print(len(x_test), "test sequences")
+
+  print("Pad sequences (samples x time)")
+  x_train = sequence.pad_sequences(x_train, maxlen=maxlen)
+  x_test = sequence.pad_sequences(x_test, maxlen=maxlen)
+
+  return x_train, y_train, x_test, y_test
+
+def cluster_train_eval_strip(
+    model, x_train, y_train, x_test, y_test, batch_size, test_case):
+  model = cluster.cluster_weights(
+      model,
+      number_of_clusters=16,
+      cluster_centroids_init=cluster_config.CentroidInitialization
+      .KMEANS_PLUS_PLUS,)
+
+  model.compile(loss="binary_crossentropy",
+                optimizer="adam",
+                metrics=["accuracy"])
+
+
+  print("Train...")
+  model.fit(x_train, y_train, batch_size=batch_size, epochs=1,
+            validation_data=(x_test, y_test), verbose=2)
+  score, acc = model.evaluate(x_test, y_test,
+                              batch_size=batch_size)
+
+  print("Test score:", score)
+  print("Test accuracy:", acc)
+
+  print("Strip clustering wrapper...")
+  model = cluster.strip_clustering(model)
+  if "Bidirectional" in test_case:
+    layer_weight = getattr(model.layers[1].forward_layer.cell, 'kernel')
+  elif "StackedRNNCells" in test_case:
+    layer_weight = getattr(model.layers[1].cell.cells[0], 'kernel')
+  else:
+    raise ValueError("Only Bidirectional and StackedRNNCells are tested now.")
+  print("Number of clusters:", len(set(layer_weight.numpy().flatten())))


### PR DESCRIPTION
This PR adds support for StackedRNNCells, PeepholeLSTMCell, and Bidirectional in clustering. To verify the implementation, unit tests and end-to-end tests are provided in the PR.
Below are numbers generated using the imdb_multiple_cells.py. In those experiments, the clustering wrapper was applied to a model with randomly initialized weights for 1 epoch on the IMDB dataset with a number of clusters equal to 16.

| Types of RNN layers/Cells 	| Experimental setups                               	| Accuracy in clustering experiments 	|
|---------------------------	|---------------------------------------------------	|------------------------------------	|
| StackedRNNCell            	|Two LSTMCells wrapped by a StackedRNNCell | 0.8502                             	|
| PeepholeLSTMCell          	| Two PeepholeLSTMCells wrapped by a StackedRNNCell | 0.8403                             |
| Bidirectional             	| A LSTM wrapped by a Bidirectional  | 0.8492 |
