### PR TITLE
Fix for tensorflow_model_optimization import error

### DIFF
--- a/tensorflow_model_optimization/python/core/api/BUILD
+++ b/tensorflow_model_optimization/python/core/api/BUILD
@@ -42,6 +42,7 @@ py_strict_library(
         "//tensorflow_model_optimization/python/core/quantization/keras:quantize_scheme",
         "//tensorflow_model_optimization/python/core/quantization/keras:quantize_wrapper",
         "//tensorflow_model_optimization/python/core/quantization/keras:quantizers",
+        "//tensorflow_model_optimization/python/core/quantization/keras/experimental",
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve:cluster_utils",
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve:default_8bit_cluster_preserve_quantize_scheme",
         "//tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/prune_preserve:default_8bit_prune_preserve_quantize_scheme",

--- a/tensorflow_model_optimization/python/core/quantization/keras/experimental/BUILD
+++ b/tensorflow_model_optimization/python/core/quantization/keras/experimental/BUILD
@@ -1,0 +1,25 @@
+load("//tensorflow_model_optimization:tensorflow_model_optimization.bzl", "py_strict_library")
+
+package(default_visibility = ["//tensorflow_model_optimization:__subpackages__"])
+
+licenses(["notice"])  # Apache 2.0
+
+py_strict_library(
+    name = "experimental",
+    srcs = [
+        "__init__.py",
+    ],
+    srcs_version = "PY3",
+    deps = [
+        ":quantization",  # buildcleaner: keep
+    ],
+)
+
+py_strict_library(
+    name = "quantization",
+    srcs = ["__init__.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_model_optimization/python/core/quantization/keras",  # buildcleaner: keep
+    ],
+)


### PR DESCRIPTION
This PR fixes import issues seen.

When trying the following: 
`import tensorflow_model_optimization as tfmot`

the following error occurs: 
`ModuleNotFoundError: No module named 'tensorflow_model_optimization.python.core.quantization.keras.experimental'`