### PR TITLE
Add MbyN sparsity schedulers

### DIFF
--- a/tensorflow_model_optimization/python/core/api/sparsity/keras/__init__.py
+++ b/tensorflow_model_optimization/python/core/api/sparsity/keras/__init__.py
@@ -25,6 +25,8 @@ from tensorflow_model_optimization.python.core.sparsity.keras.pruning_callbacks 
 from tensorflow_model_optimization.python.core.sparsity.keras.pruning_schedule import PruningSchedule
 from tensorflow_model_optimization.python.core.sparsity.keras.pruning_schedule import ConstantSparsity
 from tensorflow_model_optimization.python.core.sparsity.keras.pruning_schedule import PolynomialDecay
+from tensorflow_model_optimization.python.core.sparsity.keras.pruning_schedule import ConstantMbyNSparsity
+from tensorflow_model_optimization.python.core.sparsity.keras.pruning_schedule import PolynomialDecayMbyNSparsity
 
 from tensorflow_model_optimization.python.core.sparsity.keras.prunable_layer import PrunableLayer
 

--- a/tensorflow_model_optimization/python/core/sparsity/keras/prune_integration_test.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/prune_integration_test.py
@@ -373,7 +373,6 @@ class PruneIntegrationTest(tf.test.TestCase, parameterized.TestCase,
           'm_by_n': (2, 4),
       },
   )
-
   def testMbyNSparsityPruning_SupportedLayers(self,
                                               layer_type,
                                               layer_arg,
@@ -382,6 +381,8 @@ class PruneIntegrationTest(tf.test.TestCase, parameterized.TestCase,
                                               sparsity_ratio=0.50):
     """Check that we prune supported layers with m by n sparsity."""
     self.params.update({'sparsity_m_by_n': m_by_n})
+    self.params.update(
+      {'pruning_schedule': pruning_schedule.ConstantMbyNSparsity(prune_step=1)})
 
     model = keras.Sequential()
     model.add(

--- a/tensorflow_model_optimization/python/core/sparsity/keras/pruning_impl.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/pruning_impl.py
@@ -115,6 +115,11 @@ class Pruning(object):
     that n elements with the lowest absolute values in the block
     of m elements are set to be zero. We don't return any threshold.
 
+    If coverage ratio provided with the pruning schedule is less than 1.0,
+    a partially sparsity mask will be calculated and add up to m_by_n
+    sparsity mask, so that coverage ratio of m_by_n sparsity pattern
+    on mask is (coverage_ratio * 100%).
+
     Args:
       weights: The weight tensor that needs to be masked.
       m_by_n: tuple of two integers, indicating m zeros out of n consecutive
@@ -125,17 +130,40 @@ class Pruning(object):
       0 or 1 to indicate which of the values in weights should be set to zero.
       It throws an error if the requested mask cannot be created.
     """
-    prepared_weights = pruning_utils.weights_rearrange(weights)
-    mask = pruning_utils.generate_m_by_n_mask(prepared_weights, m_by_n)
-    new_mask = pruning_utils.m_by_n_sparsity_mask_prepare(mask, weights.shape)
+    coverage_ratio = self._pruning_schedule(self._step_fn())[1]
+    with tf.name_scope('m_by_n_sparsity_pruning_ops'):
+      prepared_weights = pruning_utils.weights_rearrange(weights)
 
-    return new_mask
+      mask = pruning_utils.generate_m_by_n_mask(prepared_weights, m_by_n)
+      new_mask = pruning_utils.m_by_n_sparsity_mask_prepare(mask, weights.shape)
+
+      def update_mask_sparsity_m_by_n_with_coverage_ratio():
+        partial_covered_mask = pruning_utils.generate_partial_sparsity_mask(
+            prepared_weights, m_by_n[1], coverage_ratio)
+        new_partial_covered_mask = pruning_utils.m_by_n_sparsity_mask_prepare(
+            partial_covered_mask, weights.shape)
+
+        m_by_n_mask = tf.clip_by_value(
+            new_mask + new_partial_covered_mask,
+            clip_value_min=0.0,
+            clip_value_max=1.0
+        )
+
+        return m_by_n_mask
+
+      m_by_n_mask = tf.cond(
+          tf.math.less(coverage_ratio, 1.0),
+          update_mask_sparsity_m_by_n_with_coverage_ratio,
+          lambda: new_mask,
+      )
+
+    return m_by_n_mask
 
   def _maybe_update_block_mask(self, weights):
     """Performs block-granular masking of the weights.
 
     If sparsity_m_by_n is selected, then we return the relevant pruning mask,
-    that nullify two out of four elements in the block.
+    that nullify m out of n consecutive elements in the block.
 
     Block pruning occurs only if the block_height or block_width is > 1 and
     if the weight tensor, when squeezed, has ndims = 2. Otherwise, elementwise

--- a/tensorflow_model_optimization/python/core/sparsity/keras/pruning_impl.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/pruning_impl.py
@@ -268,11 +268,7 @@ class Pruning(object):
     """Returns an op to updates masks as per the pruning schedule."""
 
     def maybe_update_masks():
-      if self._sparsity_m_by_n:
-        # Update structured sparsity masks only at step 1
-        return tf.math.equal(self._step_fn(), 1)
-      else:
-        return self._pruning_schedule(self._step_fn())[0]
+      return self._pruning_schedule(self._step_fn())[0]
 
     def no_update():
       return tf.no_op()

--- a/tensorflow_model_optimization/python/core/sparsity/keras/pruning_schedule.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/pruning_schedule.py
@@ -257,3 +257,123 @@ class PolynomialDecay(PruningSchedule):
             'frequency': self.frequency
         }
     }
+
+
+class ConstantMbyNSparsity(PruningSchedule):
+  """M_by_N Sparsity Pruning Schedule with 100% coverage of sparsity mask
+  throughout training.
+  """
+
+  def __init__(self, prune_step=0):
+    """Initializes a M_by_N Pruning schedule with fully coverage.
+
+    m_by_n sparsity masks calculate and apply on weights at prune_step,
+    they will not be updated after, but keep applying on the weights
+    during the training process.
+    The m_by_n sparsity coverage ratio remain constant as 100%.
+
+    Args:
+      prune_step: Step at which apply m_by_n sparsity pruning.
+    """
+    self.prune_step = prune_step
+
+    if prune_step < 0:
+      raise ValueError('prune_step should be >= 0')
+
+  def _should_prune_in_step(self, step, prune_step):
+      return tf.math.equal(step, prune_step)
+
+  def __call__(self, step):
+    return (self._should_prune_in_step(step, self.prune_step),
+            tf.constant(1.0, dtype=tf.float32))
+
+  def get_config(self):
+    return {
+        'class_name': self.__class__.__name__,
+        'config': {
+            'prune_step': self.prune_step
+        }
+    }
+
+
+class PolynomialDecayMbyNSparsity(PruningSchedule):
+  """M_by_N Sparsity Pruning Schedule with polynomial decay of
+  coverage ratio.
+  """
+
+  def __init__(
+      self,
+      initial_coverage_ratio,
+      begin_step,
+      end_step,
+      power=3.0,
+      frequency=100
+  ):
+    """Initializes a M_by_N Pruning schedule with polynomial decay of coverage
+    ratio.
+
+      Coverage ratio grows rapidly in the beginning from
+      initial_coverage_ratio, then plateaus slowly to 100% coverage.
+
+      The function applied a polynomial decay function.
+      This schedule applies a polynomial decay function to m_by_n sparsity
+      coverage ratio in the interval [`begin_step`, `end_step`],
+      given a provided `initial_coverage_ratio`, to reach an 100% coverage
+      ratio at the `end_step`.
+
+      Args:
+        initial_coverage_ratio: coverage ratio of m_by_n sparsity at which
+          the pruning begins.
+        begin_step: Step at which to begin m_by_n sparsity pruning.
+        end_step: Step at which to end m_by_n sparsity pruning, reach an 100%
+          coverage ratio.
+        power: The power of the polynomial, defaults to 3.0.
+        frequency: Only apply pruning every `frequency` steps, defaults to 100.
+    """
+    self.initial_coverage_ratio = initial_coverage_ratio
+    self.power = power
+
+    self.begin_step = begin_step
+    self.end_step = end_step
+    self.frequency = frequency
+
+    self._has_build_polynomial_decay = False
+
+    self._validate_step(self.begin_step, self.end_step, self.frequency, False)
+    self._validate_sparsity(initial_coverage_ratio, 'initial_coverage_ratio')
+
+  def _build_polynomial_decay(self):
+    self._has_build_polynomial_decay = True
+    self._coverage_ratio_polynomial_decay = (
+        tf.keras.optimizers.schedules.PolynomialDecay(
+            self.initial_coverage_ratio,
+            self.end_step - self.begin_step,  # decay steps
+            1.0,  # final_coverage_ratio
+            power=self.power,
+            cycle=False,
+            name='MbyNCoverageRatioPolynomialDecay',
+        )
+    )
+
+  def __call__(self, step):
+    if not self._has_build_polynomial_decay:
+      self._build_polynomial_decay()
+
+    return (
+      self._should_prune_in_step(step, self.begin_step, self.end_step,
+                                 self.frequency),
+      self._coverage_ratio_polynomial_decay(step - self.begin_step),
+    )
+
+  def get_config(self):
+
+    return {
+        'class_name': self.__class__.__name__,
+        'config': {
+            'initial_coverage_ratio': self.initial_coverage_ratio,
+            'power': self.power,
+            'begin_step': self.begin_step,
+            'end_step': self.end_step,
+            'frequency': self.frequency,
+        }
+    }

--- a/tensorflow_model_optimization/python/examples/sparsity/keras/mnist/mnist_e2e_sparsity2x4.py
+++ b/tensorflow_model_optimization/python/examples/sparsity/keras/mnist/mnist_e2e_sparsity2x4.py
@@ -30,7 +30,7 @@ from tensorflow_model_optimization.python.core.sparsity.keras import pruning_sch
 from tensorflow_model_optimization.python.core.sparsity.keras import pruning_utils
 from tensorflow_model_optimization.python.core.sparsity.keras import pruning_wrapper
 
-ConstantSparsity = pruning_schedule.ConstantSparsity
+PolynomialDecayMbyNSparsity = pruning_schedule.PolynomialDecayMbyNSparsity
 keras = tf.keras
 l = keras.layers
 
@@ -122,8 +122,9 @@ def main(unused_argv):
   # Train a model with sparsity 2x4.
   ##############################################################################
   pruning_params = {
-      'pruning_schedule': ConstantSparsity(0.5, begin_step=0, frequency=100),
-      'sparsity_m_by_n': (2, 4),
+      'pruning_schedule':
+          PolynomialDecayMbyNSparsity(0.25, begin_step=200, end_step=300, frequency=10),
+       'sparsity_m_by_n': (2, 4),
   }
 
   model = build_layerwise_model(input_shape, **pruning_params)
@@ -140,7 +141,7 @@ def main(unused_argv):
 
   print('evaluate pruned model: ')
   print(keras_test_utils.eval_mnist_tflite(model_content=tflite_model))
-  # the accuracy of 2:4 pruning model is 0.9866
+  # the accuracy of 2:4 pruning model is 0.9873
   # the accuracy of unstructured model with 50% is 0.9863
 
 


### PR DESCRIPTION
This PR introduce two new schedulers for M_by_N sparsity
  - PolynomialDecayMbyNSparsity
  - ConstantMbyNSparsity

#### [ConstantMbyNSparsity](https://github.com/tensorflow/model-optimization/pull/855/files#diff-15df3b8c3fdb2a06997a17f8c698e97b2e5533f85822bcba244be45b7d92f8bdR262-R277)
Pruning model at step `prune_step`, that is,  m_by_n sparsity masks calculate only at `prune_step` then remain constant and keep fully apply on the weights.
```python3
# apply 2 by 4 sparsity with a constant scheduler
# sparsity masks only calculate at step 1, they remain constant and
# keep fully apply on the weights till training finished.
pruning_params = {
    'pruning_schedule': tfmot.sparsity.keras.ConstantMbyNSparsity(prune_step=1),
    'sparsity_m_by_n': (2, 4),
}
```

#### [PolynomialDecayMbyNSparsity](https://github.com/tensorflow/model-optimization/pull/855/files#diff-15df3b8c3fdb2a06997a17f8c698e97b2e5533f85822bcba244be45b7d92f8bdR299-R332)
Pruning the model between range [`begin_step`, `end_step`] in every `frequency` number of steps. m_by_n sparsity masks been update in every `_should_prune_in_step` steps, and apply on the weights according to `coverage_ratio`. 
```python3
# apply 2 by 4 sparsity with polynomial decay scheduler
# sparsity masks update between [1, 10] in every training step, and
# keep apply partially to weights according to coverage_ratio
# coverage_ratio increase linearly(power=1.0) from 0.0 to 1.0
# at the end_step, 2 by 4 sparsity masks fully apply on weights
pruning_params = {
    'pruning_schedule':
        tfmot.sparsity.keras. PolynomialDecayMbyNSparsity(
            initial_coverage_ratio=0.0, begin_step=1,
            end_step=10, power=1.0, frequency=1),
    'sparsity_m_by_n': (2, 4),
}
```
*(with a 2D 4x4 weight tensor, scheduled 2 by 4 mask could be [example](https://github.com/tensorflow/model-optimization/pull/855/files#diff-e78cbb492cf9507d5b29b95dc1802e5d44b83fcbe0e22ce1f6d3aeafe2df6288R348-R385))*