### PR TITLE
Per-channel Clustering Implementation and Tests

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -579,5 +579,52 @@ class ClusterMHAIntegrationTest(tf.test.TestCase, parameterized.TestCase):
         nr_unique_weights = len(np.unique(weight.numpy()))
         assert nr_unique_weights == self.nr_of_clusters
 
+class ClusterPerChannelIntegrationTest(tf.test.TestCase, parameterized.TestCase):
+  """Integration tests for per-channel clustering of Conv2D layer."""
+
+  def setUp(self):
+    self.x_train = np.random.uniform(size=(500, 32, 32))
+    self.y_train = np.random.randint(low=0, high=1024, size=(500,))
+
+    self.nr_of_clusters = 4
+    self.num_channels = 12
+    self.params_clustering = {
+      "number_of_clusters": self.nr_of_clusters,
+      "cluster_centroids_init": CentroidInitialization.KMEANS_PLUS_PLUS,
+      "cluster_per_channel": True
+    }
+
+  def _get_model(self):
+    """Returns functional model with Conv2D layer."""
+    inp = tf.keras.layers.Input(shape=(32,32), batch_size=100)
+    x = tf.keras.layers.Reshape((32, 32, 1))(inp)
+    x = tf.keras.layers.Conv2D(
+        filters=self.num_channels, kernel_size=(3, 3),
+        activation='relu')(x)
+    x = tf.keras.layers.MaxPool2D(2, 2)(x)
+    out = tf.keras.layers.Flatten()(x)
+    model = tf.keras.Model(inputs=inp, outputs=out)
+    return model
+
+  @keras_parameterized.run_all_keras_modes
+  def testPerChannel(self):
+    model = self._get_model()
+
+    clustered_model = cluster.cluster_weights(model, **self.params_clustering)
+
+    clustered_model.compile(
+      optimizer=tf.keras.optimizers.Adam(learning_rate=1e-4),
+      loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+      metrics=[tf.keras.metrics.SparseCategoricalAccuracy(name='accuracy')])
+    clustered_model.fit(self.x_train, self.y_train, epochs=1, batch_size=100, verbose=1)
+
+    stripped_model = cluster.strip_clustering(clustered_model)
+
+    layerConv2D = stripped_model.layers[2]
+    for weight in layerConv2D.weights:
+      if 'kernel' in weight.name:
+        nr_unique_weights = len(np.unique(weight.numpy()))
+        assert nr_unique_weights == self.nr_of_clusters*self.num_channels
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_wrapper.py
@@ -58,6 +58,7 @@ class ClusterWeights(Wrapper):
                number_of_clusters,
                cluster_centroids_init=CentroidInitialization.KMEANS_PLUS_PLUS,
                preserve_sparsity=False,
+               cluster_per_channel=False,
                cluster_gradient_aggregation=GradientAggregation.SUM,
                **kwargs):
     if not isinstance(layer, Layer):
@@ -101,6 +102,17 @@ class ClusterWeights(Wrapper):
     # The number of cluster centroids
     self.number_of_clusters = number_of_clusters
 
+    # Whether to cluster Conv2D kernels per-channel.
+    # In case the layer isn't a Conv2D, this isn't
+    # applicable
+    self.cluster_per_channel = (
+      cluster_per_channel if isinstance(layer, tf.keras.layers.Conv2D)
+        else False)
+
+    # Number of channels in a Conv2D layer, to be
+    # used the case of per-channel clustering
+    self.num_channels = None
+
     # Whether to apply sparsity preservation or not
     self.preserve_sparsity = preserve_sparsity
 
@@ -137,11 +149,30 @@ class ClusterWeights(Wrapper):
         hasattr(layer, '_batch_input_shape')):
       self._batch_input_shape = self.layer._batch_input_shape
 
+    # In the case of Conv2D layer, the data_format
+    # needs to be preserved to be used for per-channel
+    # clustering
+    if hasattr(layer, 'data_format'):
+      self.data_format = self.layer.data_format
+    else:
+      self.data_format = None
+
     # Save the input shape specified in the build
     self.build_input_shape = None
 
   def _make_layer_name(self, layer):
     return '{}_{}'.format('cluster', layer.name)
+
+  def _get_zero_idx_mask(self, centroids, zero_cluster):
+    zero_idx_mask = (tf.cast(tf.math.not_equal(centroids,
+                                              zero_cluster),
+                                              dtype=tf.float32))
+    return zero_idx_mask
+
+  def _get_zero_centroid(self, centroids, zero_idx_mask):
+    zero_centroid = tf.math.multiply(centroids,
+                                     zero_idx_mask)
+    return zero_centroid
 
   def get_weight_from_layer(self, weight_name):
     return getattr(self.layer, weight_name)
@@ -173,15 +204,28 @@ class ClusterWeights(Wrapper):
           i for i, w in enumerate(self.layer.weights) if w is original_weight)
       self.position_original_weights[position_original_weight] = weight_name
 
+      # In the case of per-channel clustering, the number of channels,
+      # per-channel number of clusters, as well as the overall number
+      # of clusters all need to be preserved in the wrapper.
+      if self.cluster_per_channel:
+        self.num_channels = (
+          original_weight.shape[1] if self.data_format == "channels_first"
+            else original_weight.shape[-1])
+
+      centroid_init_factory = clustering_centroids.CentroidsInitializerFactory
+      centroid_init = centroid_init_factory.get_centroid_initializer(
+                                            self.cluster_centroids_init)(
+                                            weight, self.number_of_clusters,
+                                            self.cluster_per_channel,
+                                            self.num_channels,
+                                            self.preserve_sparsity)
+
       # Init the cluster centroids
-      cluster_centroids = (
-          clustering_centroids.CentroidsInitializerFactory
-          .get_centroid_initializer(self.cluster_centroids_init)(
-              weight, self.number_of_clusters,
-              self.preserve_sparsity).get_cluster_centroids())
+      cluster_centroids = (centroid_init.get_cluster_centroids())
+
       self.cluster_centroids[weight_name] = self.add_weight(
           '{}{}'.format('cluster_centroids_', weight_name),
-          shape=(self.number_of_clusters,),
+          shape=(cluster_centroids.shape),
           dtype=weight.dtype,
           trainable=True,
           initializer=tf.keras.initializers.Constant(value=cluster_centroids))
@@ -198,10 +242,11 @@ class ClusterWeights(Wrapper):
         weight_name_no_index = weight_name
       self.clustering_algorithms[weight_name] = (
           clustering_registry.ClusteringLookupRegistry().get_clustering_impl(
-              self.layer, weight_name_no_index)
+              self.layer, weight_name_no_index, self.cluster_per_channel)
           (
               clusters_centroids=self.cluster_centroids[weight_name],
               cluster_gradient_aggregation=self.cluster_gradient_aggregation,
+              data_format=self.data_format,
           ))
 
       # Init the pulling_indices (weights associations)
@@ -233,18 +278,27 @@ class ClusterWeights(Wrapper):
     ):
 
       if self.preserve_sparsity:
-        # Set the smallest centroid to zero to force sparsity
-        # and avoid extra cluster from forming
-        zero_idx_mask = (
-            tf.cast(
-                tf.math.not_equal(
-                    self.cluster_centroids[weight_name],
-                    self.cluster_centroids[weight_name][
-                        self.zero_idx[weight_name]]),
-                dtype=tf.float32))
-        self.cluster_centroids[weight_name].assign(
-            tf.math.multiply(self.cluster_centroids[weight_name],
-                             zero_idx_mask))
+        # In the case of per-channel clustering, sparsity
+        # needs to be preserved per-channel
+        if self.cluster_per_channel:
+          for channel in range(self.num_channels):
+            zero_idx_mask = (
+              self._get_zero_idx_mask(self.cluster_centroids[weight_name][channel],
+                                      self.cluster_centroids[weight_name][channel][
+                                      self.zero_idx[weight_name][channel]]))
+            self.cluster_centroids[weight_name][channel].assign(
+                self._get_zero_centroid(self.cluster_centroids[weight_name][channel],
+                                        zero_idx_mask))
+        else:
+          # Set the smallest centroid to zero to force sparsity
+          # and avoid extra cluster from forming
+          zero_idx_mask = self._get_zero_idx_mask(self.cluster_centroids[weight_name],
+                                                  self.cluster_centroids[weight_name][
+                                                  self.zero_idx[weight_name]])
+          self.cluster_centroids[weight_name].assign(
+              self._get_zero_centroid(self.cluster_centroids[weight_name],
+                                      zero_idx_mask))
+
         # During training, the original zero weights can drift slightly.
         # We want to prevent this by forcing them to stay zero at the places
         # where they were originally zero to begin with.
@@ -284,6 +338,7 @@ class ClusterWeights(Wrapper):
         'cluster_centroids_init': self.cluster_centroids_init,
         'preserve_sparsity': self.preserve_sparsity,
         'cluster_gradient_aggregation': self.cluster_gradient_aggregation,
+        'cluster_per_channel': self.cluster_per_channel,
         **base_config
     }
     return config
@@ -296,12 +351,14 @@ class ClusterWeights(Wrapper):
     cluster_centroids_init = config.pop('cluster_centroids_init')
     preserve_sparsity = config.pop('preserve_sparsity')
     cluster_gradient_aggregation = config.pop('cluster_gradient_aggregation')
+    cluster_per_channel = config.pop('cluster_per_channel')
 
     config['number_of_clusters'] = number_of_clusters
     config['cluster_centroids_init'] = cluster_config.CentroidInitialization(
         cluster_centroids_init)
     config['preserve_sparsity'] = preserve_sparsity
     config['cluster_gradient_aggregation'] = cluster_gradient_aggregation
+    config['cluster_per_channel'] = cluster_per_channel
 
     layer = tf.keras.layers.deserialize(
         config.pop('layer'), custom_objects=custom_objects)

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_algorithm.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_algorithm.py
@@ -41,6 +41,7 @@ class ClusteringAlgorithm(object):
       self,
       clusters_centroids,
       cluster_gradient_aggregation=GradientAggregation.SUM,
+      data_format=None
   ):
     """Generating clustered tensors.
 
@@ -52,14 +53,59 @@ class ClusteringAlgorithm(object):
         clusters centroids.
       cluster_gradient_aggregation: An enum that specify the aggregation method
         of the cluster gradient.
+      data_format: To be used in Per-Channel clustering to ensure the weight
+        kernel is permuted properly when updating the weights and calculating
+        gradients
     """
     if not isinstance(clusters_centroids, tf.Variable):
       raise ValueError("clusters_centroids should be a tf.Variable.")
 
     self.cluster_centroids = clusters_centroids
     self.cluster_gradient_aggregation = cluster_gradient_aggregation
+    self.data_format = data_format
 
-  def get_pulling_indices(self, weight):
+  @tf.custom_gradient
+  def average_centroids_gradient_by_cluster_size(self, cluster_centroids, cluster_sizes):
+
+    def grad(d_cluster_centroids):
+      # Average the gradient based on the number of weights belonging to each
+      # cluster
+      d_cluster_centroids = tf.math.divide_no_nan(d_cluster_centroids,
+                                                  cluster_sizes)
+      return d_cluster_centroids, None
+
+    return cluster_centroids, grad
+
+  @tf.custom_gradient
+  def add_gradient_to_original_weight(self, clustered_weight, original_weight):
+    """Overrides gradients in the backprop stage.
+
+    This function overrides gradients in the backprop stage: the Jacobian
+    matrix of multiplication is replaced with the identity matrix, which
+    effectively changes multiplication into add in the backprop. Since
+    the gradient of tf.sign is 0, overwriting it with identity follows
+    the design of straight-through-estimator, which accepts all upstream
+    gradients and uses them to update original non-clustered weights of
+    the layer. Here, we assume the gradient updates on individual elements
+    inside a cluster will be different so that there is no point in mapping
+    the gradient updates back to original non-clustered weights using the LUT.
+
+    Args:
+      clustered_weight: clustered weights
+      original_weight: original weights
+
+    Returns:
+      result and custom gradient, as expected by @tf.custom_gradient
+    """
+    override_weights = tf.sign(original_weight + 1e+6)
+    override_clustered_weight = clustered_weight * override_weights
+
+    def grad(d_override_clustered_weight):
+      return d_override_clustered_weight, d_override_clustered_weight
+
+    return override_clustered_weight, grad
+
+  def get_pulling_indices(self, weight, centroids=None):
     """Returns indices of closest cluster centroids.
 
     Takes a weight(can be 1D, 2D or ND) and creates tf.int32 array of the
@@ -77,10 +123,14 @@ class ClusteringAlgorithm(object):
       ND array of the same shape as `weight` parameter of the type
       tf.int32. The returned array contain weight lookup indices
     """
+
+    cluster_centroids = centroids if centroids is not None \
+      else self.cluster_centroids
+
     # We find the nearest cluster centroids and store them so that ops can build
     # their kernels upon it.
     pulling_indices = tf.argmin(
-        tf.abs(tf.expand_dims(weight, axis=-1) - self.cluster_centroids),
+        tf.abs(tf.expand_dims(weight, axis=-1) - cluster_centroids),
         axis=-1)
 
     return pulling_indices
@@ -106,61 +156,20 @@ class ClusteringAlgorithm(object):
       adding custom gradients.
     """
 
-    @tf.custom_gradient
-    def average_centroids_gradient_by_cluster_size(cluster_centroids,
-                                                   cluster_sizes):
-
-      def grad(d_cluster_centroids):
-        # Average the gradient based on the number of weights belonging to each
-        # cluster
-        d_cluster_centroids = tf.math.divide_no_nan(d_cluster_centroids,
-                                                    cluster_sizes)
-        return d_cluster_centroids, None
-
-      return cluster_centroids, grad
-
-    @tf.custom_gradient
-    def add_gradient_to_original_weight(clustered_weight, original_weight):
-      """Overrides gradients in the backprop stage.
-
-      This function overrides gradients in the backprop stage: the Jacobian
-      matrix of multiplication is replaced with the identity matrix, which
-      effectively changes multiplication into add in the backprop. Since
-      the gradient of tf.sign is 0, overwriting it with identity follows
-      the design of straight-through-estimator, which accepts all upstream
-      gradients and uses them to update original non-clustered weights of
-      the layer. Here, we assume the gradient updates on individual elements
-      inside a cluster will be different so that there is no point in mapping
-      the gradient updates back to original non-clustered weights using the LUT.
-
-      Args:
-        clustered_weight: clustered weights
-        original_weight: original weights
-
-      Returns:
-        result and custom gradient, as expected by @tf.custom_gradient
-      """
-      override_weights = tf.sign(original_weight + 1e+6)
-      override_clustered_weight = clustered_weight * override_weights
-
-      def grad(d_override_clustered_weight):
-        return d_override_clustered_weight, d_override_clustered_weight
-
-      return override_clustered_weight, grad
-
     if self.cluster_gradient_aggregation == GradientAggregation.SUM:
       cluster_centroids = self.cluster_centroids
     elif self.cluster_gradient_aggregation == GradientAggregation.AVG:
+      cluster_centroids = self.cluster_centroids
       # Compute the size of each cluster
       # (number of weights belonging to each cluster)
       cluster_sizes = tf.math.bincount(
           arr=tf.cast(pulling_indices, dtype=tf.int32),
-          minlength=tf.size(self.cluster_centroids),
-          dtype=self.cluster_centroids.dtype,
+          minlength=tf.size(cluster_centroids),
+          dtype=cluster_centroids.dtype,
       )
       # Modify the gradient of cluster_centroids to be averaged by cluster sizes
-      cluster_centroids = average_centroids_gradient_by_cluster_size(
-          self.cluster_centroids,
+      cluster_centroids = self.average_centroids_gradient_by_cluster_size(
+          cluster_centroids,
           tf.stop_gradient(cluster_sizes),
       )
     else:
@@ -172,10 +181,102 @@ class ClusteringAlgorithm(object):
     clustered_weight = tf.gather(cluster_centroids, pulling_indices)
 
     # Add an estimated gradient to the original weight
-    clustered_weight = add_gradient_to_original_weight(
+    clustered_weight = self.add_gradient_to_original_weight(
         clustered_weight,
         # Fix the bug with MirroredVariable and tf.custom_gradient:
         # tf.identity will transform a MirroredVariable into a Variable
+        tf.identity(original_weight),
+    )
+
+    return clustered_weight
+
+class PerChannelCA(ClusteringAlgorithm):
+  """Class to implement the lookup and weight update
+  functions for Per-channel clustering of Conv2D layers.
+  """
+  def get_pulling_indices(self, weight):
+    channel_indices = []
+
+    num_channels = \
+      weight.shape[1] if self.data_format == "channels_first" \
+        else weight.shape[-1]
+
+    for channel in range(num_channels):
+      channel_weights = weight[:,channel,:,:] if self.data_format == "channels_first" \
+          else weight[:,:,:,channel]
+      channel_centroids = self.cluster_centroids[channel]
+      pulling_indices = super().get_pulling_indices(channel_weights,
+                                                    channel_centroids)
+
+      channel_indices.append(pulling_indices)
+
+    return tf.convert_to_tensor(channel_indices)
+
+  def get_clustered_weight(self, pulling_indices, original_weight):
+    """Returns clustered weights with custom gradients.
+
+    Take indices the per-channel pulling_indices as input and retrieve
+    the corresponding clustered weights by using the gather operation
+    for each of the channels.
+    The original gradients will also be modified in two ways:
+    - By averaging the gradient of cluster_centroids based on the size of
+      each cluster.
+    - By adding an estimated gradient onto the non-differentiable
+      original weight.
+    Args:
+      pulling_indices: a tensor of per-channel indices used for lookup of the same size as
+        original_weight.
+      original_weight: the original weights of the wrapped layer.
+
+    Returns:
+      array with the same shape as `pulling_indices`. Each array element
+      is a member of self.cluster_centroids. The backward pass is modified by
+      adding custom gradients.
+    """
+    num_channels = \
+      original_weight.shape[1] if self.data_format == "channels_first" \
+        else original_weight.shape[-1]
+
+    if self.cluster_gradient_aggregation == GradientAggregation.SUM:
+      cluster_centroids = self.cluster_centroids
+    elif self.cluster_gradient_aggregation == GradientAggregation.AVG:
+      cluster_sizes = []
+      for i in range(num_channels):
+        # Compute the size of each cluster for each channel
+        # (number of weights belonging to each cluster)
+        cluster_sizes.append(tf.math.bincount(
+            arr=tf.cast(pulling_indices[i], dtype=tf.int32),
+            minlength=tf.size(self.cluster_centroids[i]),
+            dtype=self.cluster_centroids.dtype,
+          ))
+
+      cluster_sizes = tf.convert_to_tensor(cluster_sizes)
+
+      # Modify the gradient of cluster_centroids to be averaged by cluster sizes
+      cluster_centroids = self.average_centroids_gradient_by_cluster_size(
+          self.cluster_centroids,
+          tf.stop_gradient(cluster_sizes),
+      )
+    else:
+      raise ValueError(f"self.cluster_gradient_aggregation="
+                       f"{self.cluster_gradient_aggregation} not implemented.")
+
+    clustered_weights = []
+
+    for i in range(num_channels):
+        clustered_weights.append(tf.gather(cluster_centroids[i], pulling_indices[i]))
+
+    clustered_weight = tf.convert_to_tensor(clustered_weights)
+
+    # Permute weights to ensure the channels are first or last, as expected
+    # based on the data_format attribute
+    clustered_weight = \
+      tf.transpose(clustered_weights, perm=[1,0,2,3]) if self.data_format == "channels_first" \
+        else tf.transpose(clustered_weights, perm=[1,2,3,0])
+
+    # Add an estimated gradient to the original weight
+    clustered_weight = self.add_gradient_to_original_weight(
+        clustered_weight,
         tf.identity(original_weight),
     )
 

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids.py
@@ -43,10 +43,19 @@ class AbstractCentroidsInitialisation:
   used.
   """
 
-  def __init__(self, weights, number_of_clusters, preserve_sparsity=False):
+  def __init__(self, weights, number_of_clusters,
+               cluster_per_channel=False, data_format=None,
+               preserve_sparsity=False):
     self.weights = weights
     self.number_of_clusters = number_of_clusters
+    self.cluster_per_channel=cluster_per_channel
+    self.data_format = data_format
     self.preserve_sparsity = preserve_sparsity
+
+    if cluster_per_channel:
+      self.num_channels = (
+        weights.shape[1] if self.data_format == "channels_first"
+          else weights.shape[-1])
 
   @abc.abstractmethod
   def _calculate_centroids_for_interval(self, weight_interval,
@@ -55,12 +64,26 @@ class AbstractCentroidsInitialisation:
 
   def _regular_clustering(self):
     # Regular clustering calculates the centroids using all the weights
-    centroids = self._calculate_centroids_for_interval(self.weights,
-                                                       self.number_of_clusters)
-    cluster_centroids = tf.reshape(centroids, (self.number_of_clusters,))
+    cluster_centroids = self._calculate_centroids_for_interval(self.weights,
+                                                               self.number_of_clusters)
+
     return cluster_centroids
 
-  def _zero_centroid_initialization(self):
+  def _per_channel_clustering(self):
+
+    channel_centroids = []
+    for channel in range(self.num_channels):
+      channel_weights = (
+        self.weights[:,channel,:,:] if self.data_format == "channels_first"
+          else self.weights[:,:,:,channel])
+      channel_centroids.append(self._calculate_centroids_for_interval(channel_weights,
+                                                                      self.number_of_clusters))
+
+    cluster_centroids = tf.convert_to_tensor(channel_centroids)
+
+    return cluster_centroids
+
+  def _zero_centroid_initialization(self, weights_to_cluster=None):
     """The zero-centroid sparsity preservation technique works as follows.
 
     1. First, one centroid is set to zero explicitly
@@ -75,17 +98,23 @@ class AbstractCentroidsInitialisation:
     Returns:
       centroids.
     """
+    # In the case of per-channel clustering, set weights
+    # to be clustered to channel weights.
+    weights = (
+      weights_to_cluster if weights_to_cluster is not None
+        else self.weights)
+
     # Zero-point centroid
     zero_centroid = tf.zeros(shape=(1,))
 
     # Get the negative weights
-    negative_weights = tf.boolean_mask(self.weights,
-                                       tf.math.less(self.weights, 0))
+    negative_weights = tf.boolean_mask(weights,
+                                       tf.math.less(weights, 0))
     negative_weights_count = tf.size(negative_weights)
 
     # Get the positive weights
-    positive_weights = tf.boolean_mask(self.weights,
-                                       tf.math.greater(self.weights, 0))
+    positive_weights = tf.boolean_mask(weights,
+                                       tf.math.greater(weights, 0))
     positive_weights_count = tf.size(positive_weights)
 
     # Get the number of non-zero weights
@@ -123,11 +152,37 @@ class AbstractCentroidsInitialisation:
 
     return centroids
 
+  def _per_channel_zero_centroid_initialization(self):
+    """The per-channel sparsity-preserving centroid initialization
+    works as described in the above method, but applied to each
+    channel separately.
+    """
+
+    channel_centroids = []
+    for channel in range(self.num_channels):
+      channel_weights = (
+        self.weights[:,channel,:,:] if self.data_format == "channels_first"
+          else self.weights[:,:,:,channel])
+
+      zero_centroids = self._zero_centroid_initialization(channel_weights)
+
+      # Put all the centroids together: negative, zero, positive
+      channel_centroids.append(zero_centroids)
+
+    cluster_centroids = tf.convert_to_tensor(channel_centroids)
+
+    return cluster_centroids
+
   def get_cluster_centroids(self):
     # Check whether sparsity preservation should be enforced
     if self.preserve_sparsity:
-      # Apply the zero-centroid sparsity preservation technique
-      return self._zero_centroid_initialization()
+      if self.cluster_per_channel:
+        return self._per_channel_zero_centroid_initialization()
+      else:
+        # Apply the zero-centroid sparsity preservation technique
+        return self._zero_centroid_initialization()
+    elif self.cluster_per_channel:
+      return self._per_channel_clustering()
     else:
       # Perform regular clustering
       return self._regular_clustering()

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_centroids_test.py
@@ -15,6 +15,7 @@
 """Tests for keras clustering centroids initialisation API."""
 
 from absl.testing import parameterized
+import numpy as np
 import tensorflow as tf
 
 from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
@@ -146,7 +147,7 @@ class ClusteringCentroidsTest(tf.test.TestCase, parameterized.TestCase):
   def testLinearClusterCentroidsWithSparsityPreservation(
       self, weights, number_of_clusters, centroids):
     dbci = clustering_centroids.LinearCentroidsInitialisation(
-        weights, number_of_clusters, True)
+        weights, number_of_clusters, preserve_sparsity=True)
     calc_centroids = K.batch_get_value([dbci.get_cluster_centroids()])[0]
     self.assertSequenceAlmostEqual(centroids, calc_centroids, places=4)
 
@@ -175,7 +176,7 @@ class ClusteringCentroidsTest(tf.test.TestCase, parameterized.TestCase):
   def testDensityBasedClusterCentroidsWithSparsityPreservation(
       self, weights, number_of_clusters, centroids):
     dbci = clustering_centroids.DensityBasedCentroidsInitialisation(
-        weights, number_of_clusters, True)
+        weights, number_of_clusters, preserve_sparsity=True)
     calc_centroids = K.batch_get_value([dbci.get_cluster_centroids()])[0]
     self.assertSequenceAlmostEqual(centroids, calc_centroids, places=4)
 
@@ -186,7 +187,7 @@ class ClusteringCentroidsTest(tf.test.TestCase, parameterized.TestCase):
   def testRandomClusterCentroidsWithSparsityPreservation(
       self, weights, number_of_clusters):
     dbci = clustering_centroids.RandomCentroidsInitialisation(
-        weights, number_of_clusters, True)
+        weights, number_of_clusters, preserve_sparsity=True)
     calc_centroids = K.batch_get_value([dbci.get_cluster_centroids()])[0]
     self.assertContainsSubset(
         [0.],
@@ -212,10 +213,57 @@ class ClusteringCentroidsTest(tf.test.TestCase, parameterized.TestCase):
   def testKmeansPlusPlusClusterCentroidsWithSparsityPreservation(
       self, weights, number_of_clusters, centroids):
     kmci = clustering_centroids.KmeansPlusPlusCentroidsInitialisation(
-        weights, number_of_clusters, True)
+        weights, number_of_clusters, preserve_sparsity=True)
     calc_centroids = K.batch_get_value([kmci.get_cluster_centroids()])[0]
     self.assertSequenceAlmostEqual(centroids, calc_centroids, places=4)
 
+  @parameterized.parameters(
+      ([[[[0., 1.]], [[2., 3.]]], [[[4., 5.]], [[6., 7.]]]],
+        2,
+        [[4., 0.], [5., 1.]], "channels_last"),
+        ([[[[0., 1.]], [[2., 3.]]], [[[4., 5.]], [[6., 7.]]]],
+        2,
+        [[4., 0.], [6., 2.]], "channels_first"))
+  def testKmeansPlusPlusClusterCentroidsWithPerChannelClustering(
+      self, weights, number_of_clusters, centroids, data_format):
+    kmci = clustering_centroids.KmeansPlusPlusCentroidsInitialisation(
+        np.array(weights, dtype='float32'),
+        number_of_clusters, cluster_per_channel=True,
+        data_format=data_format)
+    calc_centroids = K.batch_get_value([kmci.get_cluster_centroids()])[0]
+    self.assertAllClose(centroids, calc_centroids)
+
+  @parameterized.parameters(
+      ([[[[0.0, 1.0]], [[2.0, 3.0]]], [[[4.0, 5.0]], [[6.0, 7.0]]]],
+        2,
+        [[0.197586, 6.01], [1.197586, 7.01]], "channels_last"),
+        ([[[[0.0, 1.0]], [[2.0, 3.0]]], [[[4.0, 5.0]], [[6.0, 7.0]]]],
+        2,
+        [[0.163103, 5.01], [2.163104, 7.01]], "channels_first"))
+  def testDensityBasedClusterCentroidsWithPerChannelClustering(
+      self, weights, number_of_clusters, centroids, data_format):
+    dbci = clustering_centroids.DensityBasedCentroidsInitialisation(
+        np.array(weights, dtype='float32'),
+        number_of_clusters, cluster_per_channel=True,
+        data_format=data_format)
+    calc_centroids = K.batch_get_value([dbci.get_cluster_centroids()])[0]
+    self.assertAllClose(centroids, calc_centroids)
+
+  @parameterized.parameters(
+      ([[[[0., 1.]], [[2., 3.]]], [[[4., 5.]], [[6., 7.]]]],
+        2,
+        [[0., 6.], [1., 7.]], "channels_last"),
+        ([[[[0., 1.]], [[2., 3.]]], [[[4., 5.]], [[6., 7.]]]],
+        2,
+        [[0., 5.], [2., 7.]], "channels_first"))
+  def testLinearClusterCentroidsWithPerChannelClustering(
+      self, weights, number_of_clusters, centroids, data_format):
+    dbci = clustering_centroids.LinearCentroidsInitialisation(
+        np.array(weights, dtype="float32"),
+        number_of_clusters, cluster_per_channel=True,
+        data_format=data_format)
+    calc_centroids = K.batch_get_value([dbci.get_cluster_centroids()])[0]
+    self.assertAllClose(centroids, calc_centroids)
 
 if __name__ == "__main__":
   tf.test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
@@ -21,13 +21,14 @@ from tensorflow_model_optimization.python.core.clustering.keras import clusterin
 
 layers = tf.keras.layers
 ClusteringAlgorithm = clustering_algorithm.ClusteringAlgorithm
+PerChannelCA = clustering_algorithm.PerChannelCA
 
 
 class ClusteringLookupRegistry(object):
   """Clustering registry to return the implementation for a layer."""
 
   @classmethod
-  def get_clustering_impl(cls, layer, weight_name):
+  def get_clustering_impl(cls, layer, weight_name, cluster_per_channel=False):
     """Returns a certain reshape/lookup implementation for a given array.
 
     Args:
@@ -36,6 +37,11 @@ class ClusteringLookupRegistry(object):
     Returns:
       A concrete implementation of a lookup algorithm.
     """
+
+    # Per-channel clustering is only applied if the layer is a Conv2D,
+    # ignored otherwise
+    if cluster_per_channel and isinstance(layer, tf.keras.layers.Conv2D):
+      return PerChannelCA
 
     # Clusterable layer could provide own implementation of get_pulling_indices
     if (issubclass(layer.__class__, clusterable_layer.ClusterableLayer) and

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
@@ -183,6 +183,52 @@ class ClusteringAlgorithmTest(tf.test.TestCase, parameterized.TestCase):
     )
     self._check_pull_values(clustering_algo, pulling_indices, expected_output)
 
+  @parameterized.parameters(
+      ([[0., 1, 2], [3, 4, 5]],
+      [[[[0], [0]], [[0], [1]]],
+       [[[0], [2]], [[1], [0]]]],
+      [[[[0], [0]], [[0], [0]]],
+       [[[0], [0]], [[1], [1]]]]
+      )
+  )
+  def testConvolutionalWeightsPerChannelCA(self, clustering_centroids, pulling_indices,
+                                           expected_output):
+    """Verifies that PerChannelCA works as expected."""
+    clustering_centroids = tf.Variable(clustering_centroids, dtype=tf.float32)
+    clustering_algo = clustering_registry.PerChannelCA(
+        clustering_centroids, GradientAggregation.SUM
+    )
+    self._check_pull_values(clustering_algo, pulling_indices, expected_output)
+
+  @parameterized.parameters(
+      (GradientAggregation.AVG,
+       [[[[0], [0]], [[0], [1]]],
+       [[[0], [2]], [[1], [0]]]], [[1, 1, 0], [1, 1, 1]]),
+      (GradientAggregation.SUM,
+       [[[[0], [0]], [[0], [1]]],
+       [[[0], [2]], [[1], [0]]]], [[3, 1, 0], [2, 1, 1]])
+  )
+  def testConvolutionalPerChannelCAGrad(self,
+                                        cluster_gradient_aggregation,
+                                        pulling_indices,
+                                        expected_grad_centroids):
+    """Verifies that the gradients of convolutional layer work as expected
+    when using per-channel clustering algorithm."""
+
+    clustering_centroids = tf.Variable([[0., 1, 2], [3, 4, 5]], dtype=tf.float32)
+    weight = tf.constant([[[[0.1, 3.0]], [[0.2, 0.1]]],
+                         [[[0.1, 3.0]], [[0.2, 0.1]]]])
+
+    clustering_algo = clustering_registry.PerChannelCA(
+        clustering_centroids, cluster_gradient_aggregation
+    )
+    self._check_gradients_clustered_weight(
+        clustering_algo,
+        weight,
+        pulling_indices,
+        expected_grad_centroids,
+    )
+
 
 class CustomLayer(layers.Layer):
   """A custom non-clusterable layer class."""

--- a/tensorflow_model_optimization/python/core/clustering/keras/experimental/cluster.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/experimental/cluster.py
@@ -25,6 +25,7 @@ def cluster_weights(
     number_of_clusters,
     cluster_centroids_init=CentroidInitialization.KMEANS_PLUS_PLUS,
     preserve_sparsity=False,
+    cluster_per_channel=False,
     **kwargs):
   """Modify a keras layer or model to be clustered during training (experimental).
 
@@ -107,4 +108,6 @@ def cluster_weights(
     an unsupported layer.
   """
   return _cluster_weights(to_cluster, number_of_clusters,
-                          cluster_centroids_init, preserve_sparsity, **kwargs)
+                          cluster_centroids_init,
+                          preserve_sparsity,
+                          cluster_per_channel, **kwargs)


### PR DESCRIPTION
This PR extends the clustering implementation to include support for per-channel clustering of Conv2D layers.

## Per-channel clustering for convolution 2D layers
The current clustering API allows for restricting the unique number of weights of a layer to a maximum given value. For the time being, this is done on a per-layer basis for all supported operators, including Conv2D layers. 

This PR implements the changes necessary in the clustering flow to enable per-channel clustering for Conv2D layers, in which the whole weight kernel is not clustered as one, but the channels in it are treated separately, so that each of them has the requested number of unique weights. 

This would improve the performance of Conv2D layers as it is less restrictive and would increase the representation power achievable by the convolution weight kernel. This is also particularly useful for the clustering→ quantization flow, since quantization is done per-channel, so for example, when we cluster per-layer to 8 clusters, and then we do quantization per-channel,  we end up with 8*3 (24) clusters (in the case of 3 channels), so supporting per-channel clustering scheme allows us to cluster with 24 clusters (8 per channel) from the beginning and not to restrict ourself with 8 clusters.

### User API

The PR does not introduce any fundamental or breaking changes to the existing API, but introduces a new optional flag, cluster_per_channel, that can be passed to `tfmot.clustering.keras.cluster_weights()`. As per the current usage, it would be passed as part of a kwargs dict,as shown below.

```
clustering_params = {
      "number_of_clusters": 8,
      "cluster_centroids_init": CentroidInitialization.KMEANS_PLUS_PLUS,
      "cluster_per_channel": True
    }
clustered_model = tfmot.clustering.keras.cluster_weights(model, **clustering_params)
```
#### Behaviour

The behaviour of the `cluster_weights()` API remains the same when setting the cluster_per_channel flag to True, accepting a layer or a model to cluster. The behaviour in the respective cases is as follows:

- A Layer: if the layer is a Conv2D layer, it is clustered per-channel, using the number_of_clusters parameter as the number of clusters for each channel (filter) of the layer, where the final number of clusters is expected to be less than or equal to num_channels*number_of_clusters. If the layer is not a Conv2D, it is clustered per-layer and cluster_per_channel is set internally to False, as it is not applicable to non-Conv2D layers.
- A Model: in the case of a model being passed to cluster, all the Conv2D layers of the model are all clustered per-channel and all the clusterable non-Conv2D layer are clustered per-layer.

This implementation also works as expected when preserve_sparsity flag is set to True, treating the zero centroid as a separate cluster for each channel and preserving it during weight updates. In this case, the final expected (per-layer) number of clusters would be (num_clusters - 1)*num_channels + 1.

### Implementation

The core of the implementation, aside from extending the wrappers to accept the new flag, is the addition of new methods for per-channel centroid initialization in `clustering_centroids.py`, shown below.

```
  def _per_channel_clustering(self):

    channel_centroids = []

    for channel in range(self.num_channels):

      channel_weights = \
        self.weights[:,channel,:,:] if self.data_format == "channels_first" \
          else self.weights[:,:,:,channel]

      channel_centroids.append(self._calculate_centroids_for_interval(channel_weights,
                                                                      self.number_of_clusters))

    cluster_centroids = tf.convert_to_tensor(channel_centroids)

    return cluster_centroids
    
def _per_channel_zero_centroid_initialization(self):
    """The per-channel sparsity-preserving centroid initialization
    works as described in the above method, but applied to each
    channel separately.
    """

    channel_centroids = []
    for channel in range(self.num_channels):
      channel_weights = \
        self.weights[:,channel,:,:] if self.data_format == "channels_first" \
          else self.weights[:,:,:,channel]

      zero_centroids = self._zero_centroid_initialization(channel_weights)

      # Put all the centroids together: negative, zero, positive
      channel_centroids.append(zero_centroids)

    cluster_centroids = tf.convert_to_tensor(channel_centroids)

    return cluster_centroids
```

And the implementation of a new per-channel ClusteringAlgorithm to manage the updates and weight gathering of the per-channel clustered weights during training, which can be found in `clustering_algorithm.py`.

### Results

Results will be added to the comments as we run tests on different models.