### PR TITLE
[Pruning, sparsity 2 by 4 documentation]

### DIFF
--- a/tensorflow_model_optimization/g3doc/guide/pruning/index.md
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/index.md
@@ -11,6 +11,8 @@ fits with your use case.
     [pruning comprehensive guide](comprehensive_guide.ipynb).
 *   To explore the application of pruning for on-device inference, see the
     [Pruning for on-device inference with XNNPACK](pruning_for_on_device_inference.ipynb).
+*   To see an example of structural pruning, see the
+    [Structural pruning with sparsity 2 by 4](pruning_with_sparsity_2_by_4.ipynb).
 
 ## Overview
 
@@ -126,3 +128,55 @@ pruning:
 
 For background, see *To prune, or not to prune: exploring the efficacy of
 pruning for model compression* [[paper](https://arxiv.org/pdf/1710.01878.pdf)].
+
+## Structural pruning M by N
+
+Structural pruning zeroes out model weights at the beginning of the training
+process according to the following pattern: M weights are set to zero in the
+block of N weights. It is important to notice that this pattern affects only the last dimension of the weight tensor for the model that is converted by TensorFlow Lite. For example, `Conv2D` layer weights in TensorFlow Lite have the structure [channel_out, height, width, channel_in] and `Dense` layer weights have the structure [channel_out, channel_in]. The sparsity pattern is applied to the weights in the last dimension: channel_in.
+Special hardware can benefit from this type of sparsity in the model and inference time can have a speedup up to 2x. Because this pattern lock in sparsity is more restrictive, the accuracy achieved after fine-tuning is worse than with the magnitude-based pruning.
+It is important to indicate that the pattern is valid only for the model that is converted to tflite.
+If the model is quantized, then the accuracy could be improved using [collaborative optimization technique](https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html): Sparsity preserving quantization aware training.
+
+The table below provides some results for 2 by 4 sparsity in comparison with the magnitude based pruning with the same target sparsity 50%.
+
+<figure>
+  <table>
+    <tr>
+      <th>Model</th>
+      <th>unpruned</th>
+      <th>2/4 sparsity </th>
+      <th>magnitude based sparsity, 50% </th>
+    </tr>
+    <tr>
+      <td>Inception-V3</td>
+      <td>77.82</td>
+      <td>75.8</td>
+      <td>77.47 </td>
+    </tr>
+    <tr>
+      <td>DS-CNN-L</td>
+      <td>95.23</td>
+      <td>94.33</td>
+      <td>94.84</td>
+    </tr>
+    <tr>
+      <td>MobileNet-V1</td>
+      <td>70.97</td>
+      <td>67.35</td>
+      <td>69.46</td>
+    </tr>
+    <tr>
+      <td>MobileNet-V2</td>
+      <td>71.77</td>
+      <td>66.75</td>
+      <td>69.64</td>
+    </tr>
+ </table>
+</figure>
+
+Note: DS-CNN-L is a keyword spotting model created for edge devices. It can be found
+in [Arm’s ML Examples repository](https://github.com/ARM-software/ML-examples/tree/master/tflu-kws-cortex-m).
+
+The tutorial [Structural pruning with sparsity 2 by 4](pruning_with_sparsity_2_by_4.ipynb)
+provides more information on this topic.

--- a/tensorflow_model_optimization/g3doc/guide/pruning/index.md
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/index.md
@@ -131,9 +131,9 @@ in [Arm’s ML Examples repository](https://github.com/ARM-software/ML-examples/
   <table>
     <tr>
       <th>Model</th>
-      <th>Unpruned</th>
-      <th>Sparsity 2 by 4 </th>
-      <th>Sparsity, 50% </th>
+      <th>Non-sparse Accuracy</th>
+      <th>Structured Sparse Accuracy (2 by 4 pattern)</th>
+      <th>Random Sparse Accuracy (target sparsity 50%)</th>
     </tr>
     <tr>
       <td>DS-CNN-L</td>

--- a/tensorflow_model_optimization/g3doc/guide/pruning/index.md
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/index.md
@@ -11,7 +11,7 @@ fits with your use case.
     [pruning comprehensive guide](comprehensive_guide.ipynb).
 *   To explore the application of pruning for on-device inference, see the
     [Pruning for on-device inference with XNNPACK](pruning_for_on_device_inference.ipynb).
-*   To see an example of structural pruning, see the
+*   To see an example of structural pruning, run the tutorial
     [Structural pruning with sparsity 2 by 4](pruning_with_sparsity_2_by_4.ipynb).
 
 ## Overview
@@ -43,18 +43,6 @@ It is on our roadmap to add support in the following areas:
 *   [Minimal Subclassed model support](https://github.com/tensorflow/model-optimization/issues/155)
 *   [Framework support for latency improvements](https://github.com/tensorflow/model-optimization/issues/173)
 
-## Structural pruning M by N
-
-Structural pruning zeroes out model weights at the beginning of the training
-process according to the following pattern: M weights are set to zero in the
-block of N weights. It is important to notice that this pattern affects only the last dimension of the weight tensor for the model that is converted by TensorFlow Lite. For example, `Conv2D` layer weights in TensorFlow Lite have the structure [channel_out, height, width, channel_in] and `Dense` layer weights have the structure [channel_out, channel_in]. The sparsity pattern is applied to the weights in the last dimension: channel_in.
-Special hardware can benefit from this type of sparsity in the model and inference time can have a speedup up to 2x. Because this pattern lock in sparsity is more restrictive, the accuracy achieved after fine-tuning is worse than with the magnitude-based pruning.
-It is important to indicate that the pattern is valid only for the model that is converted to tflite.
-If the model is quantized, then the accuracy could be improved using [collaborative optimization technique](https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html): Sparsity preserving quantization aware training.
-
-The tutorial [Structural pruning with sparsity 2 by 4](pruning_with_sparsity_2_by_4.ipynb)
-provides more information on this topic.
-
 ## Results
 
 ### Image Classification
@@ -64,16 +52,18 @@ provides more information on this topic.
     <tr>
       <th>Model</th>
       <th>Non-sparse Top-1 Accuracy </th>
-      <th>Sparse Accuracy </th>
-      <th>Sparsity 2 by 4</th>
-      <th>Sparsity </th>
+      <th>Random Sparse Accuracy </th>
+      <th>Random Sparsity </th>
+      <th>Structured Sparse Accuracy</th>
+      <th>Structured Sparsity </th>
     </tr>
     <tr>
       <td rowspan=3>InceptionV3</td>
       <td rowspan=3>78.1%</td>
       <td>78.0%</td>
-      <td>75.8%</td>
       <td>50%</td>
+      <td>75.8%</td>
+      <td>2 by 4</td>
     </tr>
     <tr>
       <td>76.1%</td><td>75%</td>
@@ -82,10 +72,10 @@ provides more information on this topic.
       <td>74.6%</td><td>87.5%</td>
     </tr>
     <tr>
-      <td>MobilenetV1 224</td><td>71.04%</td><td>70.84%</td><td>67.35%</td><td>50%</td>
+      <td>MobilenetV1 224</td><td>71.04%</td><td>70.84%</td><td>50%</td><td>67.35%</td><td>2 by 4</td>
     </tr>
     <tr>
-      <td>MobilenetV2 224</td><td>71.77%</td><td>69.64%</td><td>66.75%</td><td>50%</td>
+      <td>MobilenetV2 224</td><td>71.77%</td><td>69.64%</td><td>50%</td><td>66.75%</td><td>2 by 4</td>
     </tr>
  </table>
 </figure>

--- a/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb
@@ -1,0 +1,571 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2021 The TensorFlow Authors."
+      ],
+      "metadata": {
+        "id": "Tce3stUlHN0L"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "outputs": [],
+      "metadata": {
+        "cellView": "form",
+        "id": "IcfrhafzkZbH"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Structural pruning M by N"
+      ],
+      "metadata": {
+        "id": "qFdPvlXBOdUN"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/model_optimization/guide/pruning/pruning_with_sparsity_2_by_4\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/model-optimization/blob/master/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/model-optimization/blob/master/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/model-optimization/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
+      ],
+      "metadata": {
+        "id": "MfBg1C5NB3X0"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Welcome to the guide on the structural pruning M by N.\n",
+        "\n",
+        "Before reading this tutorial it is recommended to get familiar with the concept of pruning and APIs for unstructured pruning:\n",
+        "*  General overview of the pruning technique for the model optimization, see the [overview](https://www.tensorflow.org/model_optimization/guide/pruning).\n",
+        "*  Usage of API's on a single end-to-end example, see the [pruning example](https://www.tensorflow.org/model_optimization/guide/pruning/pruning_with_keras).\n",
+        "\n",
+        "In this tutorial, you will:\n",
+        "* Define and train a model on the mnist dataset with structural sparsity 2 by 4\n",
+        "* Convert the pruned model to tflite format\n",
+        "* Visualize structure of the pruned weights\n"
+      ],
+      "metadata": {
+        "id": "FbORZA_bQx1G"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Setup"
+      ],
+      "metadata": {
+        "id": "nuABqZnXVDvO"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "For finding the APIs you need and understanding purposes, you can run but skip reading this section."
+      ],
+      "metadata": {
+        "id": "u9mRDekZEfnR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "! pip install -q tensorflow\n",
+        "! pip install -q tensorflow-model-optimization\n",
+        "! pip install -q matplotlib"
+      ],
+      "outputs": [],
+      "metadata": {
+        "cellView": "both",
+        "id": "lvpH1Hg7ULFz"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "import tensorflow_model_optimization as tfmot\n",
+        "prune_low_magnitude = tfmot.sparsity.keras.prune_low_magnitude\n",
+        "\n",
+        "from tensorflow import keras"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Define model and train with structural pruning : 2 by 4"
+      ],
+      "metadata": {
+        "id": "TZyLYFTER4aP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "# Load MNIST dataset.\n",
+        "mnist = keras.datasets.mnist\n",
+        "(train_images, train_labels), (test_images, test_labels) = mnist.load_data()\n",
+        "\n",
+        "# Normalize the input image so that each pixel value is between 0 and 1.\n",
+        "train_images = train_images / 255.0\n",
+        "test_images = test_images / 255.0"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Define parameters for pruning and specify the type of structural pruning that will be used: (2, 4).\n",
+        "It means that in a block of four elements, two with the lowest magnitude will be set to zero.\n",
+        "\n",
+        "We don't set `pruning_schedule` parameter. By default, the pruning mask is defined at the first step and it is not updated during the training."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "pruning_params_2_by_4 = {\n",
+        "    'sparsity_m_by_n': (2, 4),\n",
+        "}"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Define parameters for unstructured pruning with the same target sparsity: 50%."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "pruning_params_unstructured = {\n",
+        "    'pruning_schedule': tfmot.sparsity.keras.ConstantSparsity(target_sparsity=0.5,\n",
+        "                                                              begin_step=0,\n",
+        "                                                              frequency=100)\n",
+        "}"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Define the model architecture and specify which layers to prune. Structural pruning is applied selectively to the model.\n",
+        "\n",
+        "In the example below, we prune only some of the layers. We prune `Conv2D` layer with the biggest number of parameters and an internal `Dense` layer.\n",
+        "\n",
+        "It is important to notice that even if we marked the first `Conv2D` layer to be structural pruned, it is not structurally pruned, because the number of input channels is 1. Therefore, we prune the first `Conv2D` layer with the unstructured pruning.\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "model = keras.Sequential([\n",
+        "    prune_low_magnitude(\n",
+        "        keras.layers.Conv2D(\n",
+        "            32, 5, padding='same', activation='relu',\n",
+        "            input_shape=(28, 28, 1),\n",
+        "            name=\"unstructured_pruning\"),\n",
+        "        **pruning_params_unstructured),\n",
+        "    keras.layers.MaxPooling2D((2, 2), (2, 2), padding='same'),\n",
+        "    prune_low_magnitude(\n",
+        "        keras.layers.Conv2D(\n",
+        "            64, 5, padding='same',\n",
+        "            name=\"structural_pruning\"),\n",
+        "        **pruning_params_2_by_4),\n",
+        "    keras.layers.BatchNormalization(),\n",
+        "    keras.layers.ReLU(),\n",
+        "    keras.layers.MaxPooling2D((2, 2), (2, 2), padding='same'),\n",
+        "    keras.layers.Flatten(),\n",
+        "    prune_low_magnitude(\n",
+        "        keras.layers.Dense(\n",
+        "            1024, activation='relu',\n",
+        "            name=\"structural_pruning_dense\"),\n",
+        "        **pruning_params_2_by_4),\n",
+        "    keras.layers.Dropout(0.4),\n",
+        "    keras.layers.Dense(10, activation='softmax')\n",
+        "])\n",
+        "\n",
+        "model.compile(optimizer='adam',\n",
+        "              loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+        "              metrics=['accuracy'])\n",
+        "\n",
+        "model.summary()"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Train and evaluate the model."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "batch_size = 128\n",
+        "epochs = 2\n",
+        "\n",
+        "model.fit(\n",
+        "    train_images,\n",
+        "    train_labels,\n",
+        "    batch_size=batch_size,\n",
+        "    epochs=epochs,\n",
+        "    verbose=0,\n",
+        "    callbacks=tfmot.sparsity.keras.UpdatePruningStep(),\n",
+        "    validation_split=0.1)\n",
+        "\n",
+        "_, model_for_pruning_accuracy = model.evaluate(test_images, test_labels, verbose=0)\n",
+        "print('Pruned test accuracy:', model_for_pruning_accuracy)"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Strip the pruning wrapper."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "model = tfmot.sparsity.keras.strip_pruning(model)"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Convert model to tflite format"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "import tempfile\n",
+        "\n",
+        "converter = tf.lite.TFLiteConverter.from_keras_model(model)\n",
+        "tflite_model = converter.convert()\n",
+        "\n",
+        "_, tflite_file = tempfile.mkstemp('.tflite')\n",
+        "print('Saved converted pruned model to:', tflite_file)\n",
+        "with open(tflite_file, 'wb') as f:\n",
+        "  f.write(tflite_model)"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Visualize and check weights."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now let visualize the weights structure in the `Dense` layer pruned with 2/4 sparsity. At first, we need to extract these weights from the tflite file."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "# Load tflite file with the created pruned model\n",
+        "interpreter = tf.lite.Interpreter(model_path=tflite_file)\n",
+        "interpreter.allocate_tensors()\n",
+        "\n",
+        "details = interpreter.get_tensor_details()\n",
+        "\n",
+        "# Weights of the dense layer that has been pruned.\n",
+        "tensor_name = 'structural_pruning_dense/MatMul'\n",
+        "detail = [x for x in details if tensor_name in x[\"name\"]]\n",
+        "\n",
+        "# We need the first layer.\n",
+        "tensor_data = interpreter.tensor(detail[0][\"index\"])()"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To check that we selected the layer that has been pruned, let us check the shape of the weight tensor."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "print(f\"Shape of Dense layer is {tensor_data.shape}\")"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now we visualize the structure for a small subset of the weight tensor. The structure of the weight tensor is sparse in the last dimension and has a pattern (2,4): two elements out of four are zeros. To make visualization more clear, we replace all non-zero values with ones."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "%matplotlib inline\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "\n",
+        "width = height = 24\n",
+        "\n",
+        "subset_values_to_display = tensor_data[0:height, 0:width]\n",
+        "\n",
+        "val_ones = np.ones([height, width])\n",
+        "val_zeros = np.zeros([height, width])\n",
+        "subset_values_to_display = np.where(abs(subset_values_to_display) > 0, val_ones, val_zeros)"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let us define the auxiliary function to draw separation lines to see the structure clearly."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "def plot_separation_lines(height, width):\n",
+        "\n",
+        "    block_size = [1, 4]\n",
+        "\n",
+        "    # Add separation lines to the figure.\n",
+        "    num_hlines = int((height - 1) / block_size[0])\n",
+        "    num_vlines = int((width - 1) / block_size[1])\n",
+        "    line_y_pos = [y * block_size[0] for y in range(1, num_hlines + 1)]\n",
+        "    line_x_pos = [x * block_size[1] for x in range(1, num_vlines + 1)]\n",
+        "\n",
+        "    for y_pos in line_y_pos:\n",
+        "        plt.plot([-0.5, width], [y_pos - 0.5 , y_pos - 0.5], color='w')\n",
+        "\n",
+        "    for x_pos in line_x_pos:\n",
+        "        plt.plot([x_pos - 0.5, x_pos - 0.5], [-0.5, height], color='w')"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now let us visualize the subset of the weight tensor."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "plot_separation_lines(height, width)\n",
+        "\n",
+        "plt.axis('off')\n",
+        "plt.imshow(subset_values_to_display)\n",
+        "plt.colorbar()\n",
+        "plt.title(\"Structural pruning for Dense layer\")\n",
+        "plt.show()"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let us visualize weights for `Conv2D` layer. The structural sparsity is applied in the last channel, the same way as for `Dense` layer. Only the second `Conv2D` layer is structurally pruned as it is pointed out above."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "# Let us get weights of the convolutional layer that has been pruned with 2/4 sparsity.\n",
+        "tensor_name = 'structural_pruning/Conv2D'\n",
+        "detail = [x for x in details if tensor_name in x[\"name\"]]\n",
+        "tensor_data = interpreter.tensor(detail[1][\"index\"])()\n",
+        "print(f\"Shape of the weight tensor is {tensor_data.shape}\")"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Similar to the weights of  `Dense` layer, the last dimension of the kernel has (2, 4) structure."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "weights_to_display = tf.reshape(tensor_data, [tf.reduce_prod(tensor_data.shape[:-1]), -1])\n",
+        "weights_to_display = weights_to_display[0:width, 0:height]\n",
+        "\n",
+        "val_ones = np.ones([height, width])\n",
+        "val_zeros = np.zeros([height, width])\n",
+        "subset_values_to_display = np.where(abs(weights_to_display) > 1e-9, val_ones, val_zeros)\n",
+        "\n",
+        "plot_separation_lines(height, width)\n",
+        "\n",
+        "plt.axis('off')\n",
+        "plt.imshow(subset_values_to_display)\n",
+        "plt.colorbar()\n",
+        "plt.title(\"Structurally pruned weights for Conv2D layer\")\n",
+        "plt.show()"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's see how unstructured weights look. We extract them and display a subset of the weight tensor."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "# Let us get weights of the convolutional layer that has been pruned with unstructured pruning.\n",
+        "tensor_name = 'unstructured_pruning/Conv2D'\n",
+        "detail = [x for x in details if tensor_name in x[\"name\"]]\n",
+        "tensor_data = interpreter.tensor(detail[0][\"index\"])()\n",
+        "print(f\"Shape of the weight tensor is {tensor_data.shape}\")"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "weights_to_display = tf.reshape(tensor_data, [tensor_data.shape[0],tf.reduce_prod(tensor_data.shape[1:])])\n",
+        "weights_to_display = weights_to_display[0:width, 0:height]\n",
+        "\n",
+        "val_ones = np.ones([height, width])\n",
+        "val_zeros = np.zeros([height, width])\n",
+        "subset_values_to_display = np.where(abs(weights_to_display) > 0, val_ones, val_zeros)\n",
+        "\n",
+        "plot_separation_lines(height, width)\n",
+        "\n",
+        "plt.axis('off')\n",
+        "plt.imshow(subset_values_to_display)\n",
+        "plt.colorbar()\n",
+        "plt.title(\"Unstructed pruned weights for Conv2D layer\")\n",
+        "plt.show()"
+      ],
+      "outputs": [],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "There is a python script included in the TensorFlow Model Optimization Toolkit that could be used to check whether which layers in the model from the given flite file have the structurally pruned weights: [`check_sparsity_m_by_n.py`](https://github.com/tensorflow/model-optimization/blob/master/tensorflow_model_optimization/python/core/sparsity/keras/tools/check_sparsity_m_by_n.py)."
+      ],
+      "metadata": {}
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "Tce3stUlHN0L"
+      ],
+      "name": "pruning_with_sparsity_2_by_4.ipynb",
+      "toc_visible": true
+    },
+    "interpreter": {
+      "hash": "5be03e09ac1816611305450014280c0b9eb46a3a95e12dcae8d73de01e2da776"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3.6.9 64-bit ('mo': venv)"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb
@@ -93,7 +93,7 @@
         "Structural pruning zeroes out model weights at the beginning of the training\n",
         "process according to the following pattern: M weights are set to zero in the\n",
         "block of N weights. It is important to notice that this pattern affects only the last dimension of the weight tensor for the model that is converted by TensorFlow Lite. For example, `Conv2D` layer weights in TensorFlow Lite have the structure [channel_out, height, width, channel_in] and `Dense` layer weights have the structure [channel_out, channel_in]. The sparsity pattern is applied to the weights in the last dimension: channel_in.\n",
-        "Special hardware can benefit from this type of sparsity in the model and inference time can have a speedup up to 2x. Because this pattern lock in sparsity is more restrictive, the accuracy achieved after fine-tuning is worse than with the magnitude-based pruning.\n",
+        "Special hardware can benefit from this type of sparsity in the model and inference time can have a significant speedup. Because this pattern lock in sparsity is more restrictive, the accuracy achieved after fine-tuning is worse than with the magnitude-based pruning.\n",
         "It is important to indicate that the pattern is valid only for the model that is converted to tflite.\n",
         "If the model is quantized, then the accuracy could be improved using [collaborative optimization technique](https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html): Sparsity preserving quantization aware training."
       ],
@@ -557,10 +557,12 @@
       "metadata": {}
     },
     {
-      "cell_type": "markdown",
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
-        "`python ./tensorflow_model_optimization/python/core/sparsity/keras/tools/check_sparsity_m_by_n.py --model_tflite=pruned_model.tflite --m_by_n=2,4`"
+        "! python ./tensorflow_model_optimization/python/core/sparsity/keras/tools/check_sparsity_m_by_n.py --model_tflite=pruned_model.tflite --m_by_n=2,4\n"
       ],
+      "outputs": [],
       "metadata": {}
     }
   ],

--- a/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/pruning_with_sparsity_2_by_4.ipynb
@@ -67,7 +67,7 @@
       "source": [
         "Welcome to the guide on the structural pruning M by N.\n",
         "\n",
-        "Before reading this tutorial it is recommended to get familiar with the concept of pruning and APIs for unstructured pruning:\n",
+        "Before reading this tutorial it is recommended to get familiar with the concept of pruning and APIs for random pruning:\n",
         "*  General overview of the pruning technique for the model optimization, see the [overview](https://www.tensorflow.org/model_optimization/guide/pruning).\n",
         "*  Usage of API's on a single end-to-end example, see the [pruning example](https://www.tensorflow.org/model_optimization/guide/pruning/pruning_with_keras).\n",
         "\n",
@@ -79,6 +79,25 @@
       "metadata": {
         "id": "FbORZA_bQx1G"
       }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Structural pruning M by N"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Structural pruning zeroes out model weights at the beginning of the training\n",
+        "process according to the following pattern: M weights are set to zero in the\n",
+        "block of N weights. It is important to notice that this pattern affects only the last dimension of the weight tensor for the model that is converted by TensorFlow Lite. For example, `Conv2D` layer weights in TensorFlow Lite have the structure [channel_out, height, width, channel_in] and `Dense` layer weights have the structure [channel_out, channel_in]. The sparsity pattern is applied to the weights in the last dimension: channel_in.\n",
+        "Special hardware can benefit from this type of sparsity in the model and inference time can have a speedup up to 2x. Because this pattern lock in sparsity is more restrictive, the accuracy achieved after fine-tuning is worse than with the magnitude-based pruning.\n",
+        "It is important to indicate that the pattern is valid only for the model that is converted to tflite.\n",
+        "If the model is quantized, then the accuracy could be improved using [collaborative optimization technique](https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html): Sparsity preserving quantization aware training."
+      ],
+      "metadata": {}
     },
     {
       "cell_type": "markdown",
@@ -117,11 +136,10 @@
       "execution_count": null,
       "source": [
         "import tensorflow as tf\n",
+        "from tensorflow import keras\n",
         "\n",
         "import tensorflow_model_optimization as tfmot\n",
-        "prune_low_magnitude = tfmot.sparsity.keras.prune_low_magnitude\n",
-        "\n",
-        "from tensorflow import keras"
+        "prune_low_magnitude = tfmot.sparsity.keras.prune_low_magnitude"
       ],
       "outputs": [],
       "metadata": {}
@@ -154,7 +172,7 @@
       "cell_type": "markdown",
       "source": [
         "Define parameters for pruning and specify the type of structural pruning that will be used: (2, 4).\n",
-        "It means that in a block of four elements, two with the lowest magnitude will be set to zero.\n",
+        "It means that in a block of four elements, at least two with the lowest magnitude will be set to zero.\n",
         "\n",
         "We don't set `pruning_schedule` parameter. By default, the pruning mask is defined at the first step and it is not updated during the training."
       ],
@@ -174,7 +192,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Define parameters for unstructured pruning with the same target sparsity: 50%."
+        "Define parameters for random pruning with the target sparsity: 50%."
       ],
       "metadata": {}
     },
@@ -182,7 +200,7 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "pruning_params_unstructured = {\n",
+        "pruning_params_sparsity_0_5 = {\n",
         "    'pruning_schedule': tfmot.sparsity.keras.ConstantSparsity(target_sparsity=0.5,\n",
         "                                                              begin_step=0,\n",
         "                                                              frequency=100)\n",
@@ -198,7 +216,7 @@
         "\n",
         "In the example below, we prune only some of the layers. We prune `Conv2D` layer with the biggest number of parameters and an internal `Dense` layer.\n",
         "\n",
-        "It is important to notice that even if we marked the first `Conv2D` layer to be structural pruned, it is not structurally pruned, because the number of input channels is 1. Therefore, we prune the first `Conv2D` layer with the unstructured pruning.\n"
+        "It is important to notice that even if we marked the first `Conv2D` layer to be structural pruned, it is not structurally pruned. We pruned in the channel directory, so we need to have at least 2 (or m channels) input channels. In this case, the number of input channels is 1. Therefore, we prune the first `Conv2D` layer with the random pruning.\n"
       ],
       "metadata": {}
     },
@@ -211,8 +229,8 @@
         "        keras.layers.Conv2D(\n",
         "            32, 5, padding='same', activation='relu',\n",
         "            input_shape=(28, 28, 1),\n",
-        "            name=\"unstructured_pruning\"),\n",
-        "        **pruning_params_unstructured),\n",
+        "            name=\"pruning_sparsity_0_5\"),\n",
+        "        **pruning_params_sparsity_0_5),\n",
         "    keras.layers.MaxPooling2D((2, 2), (2, 2), padding='same'),\n",
         "    prune_low_magnitude(\n",
         "        keras.layers.Conv2D(\n",
@@ -264,8 +282,8 @@
         "    callbacks=tfmot.sparsity.keras.UpdatePruningStep(),\n",
         "    validation_split=0.1)\n",
         "\n",
-        "_, model_for_pruning_accuracy = model.evaluate(test_images, test_labels, verbose=0)\n",
-        "print('Pruned test accuracy:', model_for_pruning_accuracy)"
+        "_, pruned_model_accuracy = model.evaluate(test_images, test_labels, verbose=0)\n",
+        "print('Pruned test accuracy:', pruned_model_accuracy)"
       ],
       "outputs": [],
       "metadata": {}
@@ -313,14 +331,14 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## Visualize and check weights."
+        "## Visualize and check weights"
       ],
       "metadata": {}
     },
     {
       "cell_type": "markdown",
       "source": [
-        "Now let visualize the weights structure in the `Dense` layer pruned with 2/4 sparsity. At first, we need to extract these weights from the tflite file."
+        "Now let's visualize the weights structure in the `Dense` layer pruned with 2 by 4 sparsity. At first, we need to extract these weights from the tflite file."
       ],
       "metadata": {}
     },
@@ -347,7 +365,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "To check that we selected the layer that has been pruned, let us check the shape of the weight tensor."
+        "To verify that we selected the correct layer that has been pruned, let us print the shape of the weight tensor."
       ],
       "metadata": {}
     },
@@ -376,6 +394,7 @@
         "import matplotlib.pyplot as plt\n",
         "import numpy as np\n",
         "\n",
+        "# The value 24 is chosen for convenience.\n",
         "width = height = 24\n",
         "\n",
         "subset_values_to_display = tensor_data[0:height, 0:width]\n",
@@ -450,7 +469,7 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "# Let us get weights of the convolutional layer that has been pruned with 2/4 sparsity.\n",
+        "# Let us get weights of the convolutional layer that has been pruned with 2 by 4 sparsity.\n",
         "tensor_name = 'structural_pruning/Conv2D'\n",
         "detail = [x for x in details if tensor_name in x[\"name\"]]\n",
         "tensor_data = interpreter.tensor(detail[1][\"index\"])()\n",
@@ -491,7 +510,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Let's see how unstructured weights look. We extract them and display a subset of the weight tensor."
+        "Let's see how randomly pruned weights look. We extract them and display a subset of the weight tensor."
       ],
       "metadata": {}
     },
@@ -499,8 +518,8 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "# Let us get weights of the convolutional layer that has been pruned with unstructured pruning.\n",
-        "tensor_name = 'unstructured_pruning/Conv2D'\n",
+        "# Let us get weights of the convolutional layer that has been pruned with random pruning.\n",
+        "tensor_name = 'pruning_sparsity_0_5/Conv2D'\n",
         "detail = [x for x in details if tensor_name in x[\"name\"]]\n",
         "tensor_data = interpreter.tensor(detail[0][\"index\"])()\n",
         "print(f\"Shape of the weight tensor is {tensor_data.shape}\")"
@@ -533,7 +552,14 @@
     {
       "cell_type": "markdown",
       "source": [
-        "There is a python script included in the TensorFlow Model Optimization Toolkit that could be used to check whether which layers in the model from the given flite file have the structurally pruned weights: [`check_sparsity_m_by_n.py`](https://github.com/tensorflow/model-optimization/blob/master/tensorflow_model_optimization/python/core/sparsity/keras/tools/check_sparsity_m_by_n.py)."
+        "There is a python script included in the TensorFlow Model Optimization Toolkit that could be used to check whether which layers in the model from the given flite file have the structurally pruned weights: [`check_sparsity_m_by_n.py`](https://github.com/tensorflow/model-optimization/blob/master/tensorflow_model_optimization/python/core/sparsity/keras/tools/check_sparsity_m_by_n.py). The usage of this tool for the case of 2 by 4 is shown below:"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "`python ./tensorflow_model_optimization/python/core/sparsity/keras/tools/check_sparsity_m_by_n.py --model_tflite=pruned_model.tflite --m_by_n=2,4`"
       ],
       "metadata": {}
     }


### PR DESCRIPTION
This PR adds 

- description of the structural pruning (M by N) to the pruning overview document
- a small tutorial that demonstrates how this structural pruning should be used

The tutorial uses a simple cnn model on MNIST dataset, where `Cond2D` layer and `Dense` layers are pruned with structural pruning. The model is converted to TFLite file and weights of these layers are visualize to demonstrate the pattern of structural pruning 2 by 4.