### PR TITLE
Support of clustering per channel in (P)CQAT.

### DIFF
--- a/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/cluster_integration_test.py
@@ -586,7 +586,7 @@ class ClusterMHAIntegrationTest(tf.test.TestCase, parameterized.TestCase):
 
 class ClusterPerChannelIntegrationTest(tf.test.TestCase,
                                        parameterized.TestCase):
-  """Integration tests for per-channel clustering of Conv2D layer."""
+  """Integration test for cluster_per_channel for Conv2D layer."""
 
   def setUp(self):
     super(ClusterPerChannelIntegrationTest, self).setUp()
@@ -624,15 +624,27 @@ class ClusterPerChannelIntegrationTest(tf.test.TestCase,
         loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
         metrics=[tf.keras.metrics.SparseCategoricalAccuracy(name="accuracy")])
     clustered_model.fit(
-        self.x_train, self.y_train, epochs=1, batch_size=100, verbose=1)
+        self.x_train, self.y_train, epochs=2, batch_size=100, verbose=1)
 
     stripped_model = cluster.strip_clustering(clustered_model)
 
     layer_conv2d = stripped_model.layers[2]
+    layer_conv2d_kernel_weight = None
     for weight in layer_conv2d.weights:
       if "kernel" in weight.name:
-        nr_unique_weights = len(np.unique(weight.numpy()))
-        assert nr_unique_weights == self.nr_of_clusters*self.num_channels
+        layer_conv2d_kernel_weight = weight
+    assert layer_conv2d_kernel_weight is not None
+    nr_unique_weights = len(np.unique(layer_conv2d_kernel_weight.numpy()))
+    assert nr_unique_weights == self.nr_of_clusters*self.num_channels
+
+    # The above check is too general.
+    # We need to check that we actually have nr_of_clusters per channel.
+    # If more general case passed, then we do tighter check.
+    # Note that we assume that data_format is NHWC.
+    for i in range(self.num_channels):
+      nr_unique_weights_per_channel = len(np.unique(
+        layer_conv2d_kernel_weight[:, :, :, i]))
+      assert nr_unique_weights_per_channel == self.nr_of_clusters
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
@@ -21,7 +21,7 @@ from tensorflow_model_optimization.python.core.clustering.keras import clusterin
 
 layers = tf.keras.layers
 ClusteringAlgorithm = clustering_algorithm.ClusteringAlgorithm
-PerChannelCA = clustering_algorithm.PerChannelCA
+ClusteringAlgorithmPerChannel = clustering_algorithm.ClusteringAlgorithmPerChannel
 
 
 class ClusteringLookupRegistry(object):
@@ -43,7 +43,7 @@ class ClusteringLookupRegistry(object):
     # Per-channel clustering is only applied if the layer is a Conv2D,
     # ignored otherwise
     if cluster_per_channel and isinstance(layer, tf.keras.layers.Conv2D):
-      return PerChannelCA
+      return ClusteringAlgorithmPerChannel
 
     # Clusterable layer could provide own implementation of get_pulling_indices
     if (issubclass(layer.__class__, clusterable_layer.ClusterableLayer) and

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry_test.py
@@ -184,43 +184,91 @@ class ClusteringAlgorithmTest(tf.test.TestCase, parameterized.TestCase):
     self._check_pull_values(clustering_algo, pulling_indices, expected_output)
 
   @parameterized.parameters(
-      ([[0., 1, 2], [3, 4, 5]],
-       [[[[0], [0]], [[0], [1]]],
-        [[[0], [2]], [[1], [0]]]],
-       [[[[0], [0]], [[0], [0]]],
-        [[[0], [0]], [[1], [1]]]]))
+      ("channels_last",
+        [[1, 2], [3, 4], [5, 6]], # 3 channels and 2 cluster per channel
+        # pulling indices has shape (2, 2, 1, 3)
+        [[[[0, 1, 0]], [[0, 1, 1]]], [[[1, 0, 1]], [[0, 1, 0]]]],
+        [[[[1, 4, 5]], [[1, 4, 6]]], [[[2, 3, 6]], [[1, 4, 5]]]]),
+      ("channels_first",
+        [[1, 2], [3, 4], [4, 5], [6, 7]], # 4 channels and 2 clusters per channel
+        # pulling indices has shape (1, 4, 2, 2)
+        [[[[0, 1], [1, 1]], [[0, 0], [0, 1]],
+         [[1, 0], [0, 0]], [[1, 1], [0, 0]]]],
+        [[[[1, 2], [2, 2]], [[3, 3], [3, 4]],
+        [[5, 4], [4, 4]], [[7, 7], [6, 6]]]])
+  )
   def testConvolutionalWeightsPerChannelCA(self,
+                                           data_format,
                                            clustering_centroids,
                                            pulling_indices,
                                            expected_output):
-    """Verifies that PerChannelCA works as expected."""
+    """Verifies that get_clustered_weight function works as expected."""
     clustering_centroids = tf.Variable(clustering_centroids, dtype=tf.float32)
-    clustering_algo = clustering_registry.PerChannelCA(
-        clustering_centroids, GradientAggregation.SUM
+    clustering_algo = clustering_registry.ClusteringAlgorithmPerChannel(
+        clustering_centroids, GradientAggregation.SUM, data_format
     )
+    # Note that clustered_weights has the same shape as pulling_indices,
+    # because they are defined inside of the check function.
     self._check_pull_values(clustering_algo, pulling_indices, expected_output)
 
   @parameterized.parameters(
+      ("channels_last",
+        [[1, 2], [3, 4], [5, 6]], # 3 channels and 2 cluster per channel
+        # weight has shape (2, 2, 1, 3)
+        [[[[1.1, 3.2, 5.2]], [[2.0, 4.1, 5.2]]],
+         [[[2.1, 2., 6.1]], [[1., 5., 5.]]]],
+        # expected pulling indices
+        [[[[0, 0, 0]], [[1, 1, 0]]], [[[1, 0, 1]], [[0, 1, 0]]]]),
+      ("channels_first",
+        # 4 channels and 2 clusters per channel
+        [[1, 2], [3, 4], [4, 5], [6, 7]],
+        # weight has shape (1, 4, 2, 2)
+        [[[[0.1, 1.5], [2.0, 1.1]], [[0., 3.5], [4.4, 4.]],
+         [[4.1, 4.2], [5.3, 6.]], [[7., 7.1], [6.1, 5.8]]]],
+        # expected pulling indices
+        [[[[0, 0], [1, 0]], [[0, 0], [1, 1]],
+        [[0, 0], [1, 1]], [[1, 1], [0, 0]]]])
+  )
+  def testConvolutionalPullingIndicesPerChannelCA(self,
+                                           data_format,
+                                           clustering_centroids,
+                                           weight,
+                                           expected_output):
+    """Verifies that get_pulling_indices function works as expected."""
+    clustering_centroids = tf.Variable(clustering_centroids, dtype=tf.float32)
+    clustering_algo = clustering_registry.ClusteringAlgorithmPerChannel(
+        clustering_centroids, GradientAggregation.SUM, data_format
+    )
+    weight = tf.convert_to_tensor(weight)
+    pulling_indices = clustering_algo.get_pulling_indices(weight)
+
+    # check that pulling_indices has the same shape as weight
+    self.assertEqual(pulling_indices.shape, weight.shape)
+    self.assertAllEqual(pulling_indices, expected_output)
+
+  @parameterized.parameters(
       (GradientAggregation.AVG,
-       [[[[0], [0]], [[0], [1]]],
-        [[[0], [2]], [[1], [0]]]], [[1, 1, 0], [1, 1, 1]]),
+       [[[[0, 0, 0]], [[1, 1, 0]]],
+        [[[1, 0, 1]], [[0, 1, 0]]]],
+       [[1, 1], [1, 1], [1, 1]]),
       (GradientAggregation.SUM,
-       [[[[0], [0]], [[0], [1]]],
-        [[[0], [2]], [[1], [0]]]], [[3, 1, 0], [2, 1, 1]])
+       [[[[0, 0, 0]], [[1, 1, 0]]],
+        [[[1, 0, 1]], [[0, 1, 0]]]],
+       [[2, 2], [2, 2], [3, 1]])
       )
-  def testConvolutionalPerChannelCAGrad(self,
+  def testConvolutionalPerChannelCAGradChannelsLast(self,
                                         cluster_gradient_aggregation,
                                         pulling_indices,
                                         expected_grad_centroids):
-    """Verifies that the gradients of convolutional layer work as expected."""
+    """Verifies that the gradients of convolutional layer works."""
 
-    clustering_centroids = tf.Variable([[0., 1, 2], [3, 4, 5]],
+    clustering_centroids = tf.Variable([[1, 2], [3, 4], [5, 6]],
                                        dtype=tf.float32)
-    weight = tf.constant([[[[0.1, 3.0]], [[0.2, 0.1]]],
-                          [[[0.1, 3.0]], [[0.2, 0.1]]]])
+    weight = tf.constant([[[[1.1, 3.2, 5.2]], [[2.0, 4.1, 5.2]]],
+         [[[2.1, 2., 6.1]], [[1., 5., 5.]]]])
 
-    clustering_algo = clustering_registry.PerChannelCA(
-        clustering_centroids, cluster_gradient_aggregation
+    clustering_algo = clustering_registry.ClusteringAlgorithmPerChannel(
+        clustering_centroids, cluster_gradient_aggregation, "channels_last"
     )
     self._check_gradients_clustered_weight(
         clustering_algo,
@@ -229,6 +277,37 @@ class ClusteringAlgorithmTest(tf.test.TestCase, parameterized.TestCase):
         expected_grad_centroids,
     )
 
+  @parameterized.parameters(
+      (GradientAggregation.AVG,
+       [[[[0, 0], [1, 0]], [[0, 0], [1, 1]],
+        [[0, 0], [1, 1]], [[1, 1], [0, 0]]]],
+       [[1, 1], [1, 1], [1, 1], [1, 1]]),
+      (GradientAggregation.SUM,
+       [[[[0, 0], [1, 0]], [[0, 0], [1, 1]],
+        [[0, 0], [1, 1]], [[1, 1], [0, 0]]]],
+       [[3, 1], [2, 2], [2, 2], [2, 2]])
+      )
+  def testConvolutionalPerChannelCAGradChannelsFirst(self,
+                                        cluster_gradient_aggregation,
+                                        pulling_indices,
+                                        expected_grad_centroids):
+    """Verifies that the gradients of convolutional layer works."""
+
+    clustering_centroids = tf.Variable([[1, 2], [3, 4], [4, 5], [6, 7]],
+                                       dtype=tf.float32)
+    weight = tf.constant([[[[0.1, 1.5], [2.0, 1.1]],
+        [[0., 3.5], [4.4, 4.]], [[4.1, 4.2], [5.3, 6.]],
+        [[7., 7.1], [6.1, 5.8]]]])
+
+    clustering_algo = clustering_registry.ClusteringAlgorithmPerChannel(
+        clustering_centroids, cluster_gradient_aggregation, "channels_first"
+    )
+    self._check_gradients_clustered_weight(
+        clustering_algo,
+        weight,
+        pulling_indices,
+        expected_grad_centroids,
+    )
 
 class CustomLayer(layers.Layer):
   """A custom non-clusterable layer class."""

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_integration_test.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_integration_test.py
@@ -103,6 +103,69 @@ class ClusterPreserveIntegrationTest(tf.test.TestCase, parameterized.TestCase):
 
     return clustered_model
 
+  def _get_conv_model(self, nr_of_channels, data_format=None):
+    """Returns functional model with Conv2D layer"""
+    inp = tf.keras.layers.Input(shape=(32,32), batch_size=100)
+    x = tf.keras.layers.Reshape((1, 32, 32))(inp) if \
+        data_format == "channels_first" else \
+        tf.keras.layers.Reshape((32, 32, 1))(inp)
+    x = tf.keras.layers.Conv2D(
+        filters=nr_of_channels, kernel_size=(3, 3),
+        data_format=data_format,
+        activation='relu')(x)
+    x = tf.keras.layers.MaxPool2D(2, 2)(x)
+    out = tf.keras.layers.Flatten()(x)
+    model = tf.keras.Model(inputs=inp, outputs=out)
+    return model
+
+  def _compile_and_fit_conv_model(self, model, nr_epochs=1):
+    """Compile and fit conv model from _get_conv_model"""
+    x_train = np.random.uniform(size=(500, 32, 32))
+    y_train = np.random.randint(low=0, high=1024, size=(500,))
+    model.compile(
+      optimizer=tf.keras.optimizers.Adam(learning_rate=1e-4),
+      loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+      metrics=[tf.keras.metrics.SparseCategoricalAccuracy(name='accuracy')])
+
+    model.fit(x_train, y_train, epochs=nr_epochs, batch_size=100, verbose=1)
+
+    return model
+
+  def _get_conv_clustered_model(self, nr_of_channels, nr_of_clusters,
+                                data_format, preserve_sparsity):
+    """Returns clustered per channel model with Conv2D layer"""
+    tf.random.set_seed(42)
+    model = self._get_conv_model(nr_of_channels, data_format)
+
+    if preserve_sparsity:
+      # Make the convolutional layer sparse by nullifying half of weights
+      assert model.layers[2].name == "conv2d"
+
+      conv_layer_weights = model.layers[2].get_weights()
+      shape = conv_layer_weights[0].shape
+      conv_layer_weights_flatten = conv_layer_weights[0].flatten()
+
+      nr_elems = len(conv_layer_weights_flatten)
+      conv_layer_weights_flatten[0:1+nr_elems//2] = 0.0
+      pruned_conv_layer_weights = tf.reshape(conv_layer_weights_flatten,
+                                shape)
+      conv_layer_weights[0] = pruned_conv_layer_weights
+      model.layers[2].set_weights(conv_layer_weights)
+
+    clustering_params = {
+        'number_of_clusters': nr_of_clusters,
+        'cluster_centroids_init': cluster_config.CentroidInitialization.KMEANS_PLUS_PLUS,
+        'cluster_per_channel': True,
+        'preserve_sparsity': preserve_sparsity
+    }
+
+    clustered_model = experimental_cluster.cluster_weights(model, **clustering_params)
+
+    clustered_model = self._compile_and_fit_conv_model(clustered_model)
+
+    # Returns un-stripped model
+    return clustered_model
+
   def _pcqat_training(self, preserve_sparsity, quant_aware_annotate_model):
     """PCQAT training on the input model."""
     quant_aware_model = quantize.quantize_apply(
@@ -282,6 +345,134 @@ class ClusterPreserveIntegrationTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllGreaterEqual(np.array(sparsity_pcqat),
                                sparsity_pruning[0])
     self.assertAllEqual(nr_of_unique_weights_after, unique_weights_pcqat)
+
+  def testEndToEndClusterPreserveQATClusteredPerChannel(self, data_format="channels_last"):
+    """Runs CQAT end to end for the model that is clustered per channel"""
+
+    nr_of_channels = 12
+    nr_of_clusters = 4
+
+    clustered_model = self._get_conv_clustered_model(nr_of_channels,
+                        nr_of_clusters, data_format,
+                        preserve_sparsity=False)
+    stripped_model = cluster.strip_clustering(clustered_model)
+
+    # Save the kernel weights
+    conv2d_layer = stripped_model.layers[2]
+    self.assertEqual(conv2d_layer.name, 'conv2d')
+
+    # should be nr_of_channels * nr_of_clusters
+    nr_unique_weights = -1
+
+    for weight in conv2d_layer.weights:
+      if "kernel" in weight.name:
+        nr_unique_weights = len(np.unique(weight.numpy()))
+        self.assertLessEqual(nr_unique_weights, nr_of_clusters*nr_of_channels)
+
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(stripped_model)
+    )
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme())
+
+    # Lets train for more epochs to have a chance to scatter clusters
+    model = self._compile_and_fit_conv_model(quant_aware_model, 3)
+
+    stripped_cqat_model = strip_clustering_cqat(model)
+
+    # Check the unique weights of a certain layer of
+    # clustered_model and pcqat_model
+    layer_nr = 3
+    num_of_unique_weights_cqat = self._get_number_of_unique_weights(
+        stripped_cqat_model, layer_nr, 'kernel')
+    self.assertLessEqual(num_of_unique_weights_cqat, nr_unique_weights)
+
+    # We need to do tighter check: we check that the number of unique
+    # weights per channel is less than the given nr_of_channels
+    layer = stripped_cqat_model.layers[layer_nr]
+    weight_to_check = None
+    if isinstance(layer, quantize.quantize_wrapper.QuantizeWrapper):
+      for weight_item in layer.trainable_weights:
+        if 'kernel' in weight_item.name:
+          weight_to_check = weight_item
+
+    assert weight_to_check is not None
+
+    for i in range(nr_of_channels):
+        nr_unique_weights_per_channel = len(np.unique(
+            weight_to_check[:, :, :, i]))
+        assert nr_unique_weights_per_channel == nr_of_clusters
+
+  def testEndToEndPCQATClusteredPerChannel(self, data_format = "channels_last"):
+    """Runs PCQAT end to end for the model that is clustered per channel"""
+
+    nr_of_channels = 12
+    nr_of_clusters = 4
+
+    clustered_model = self._get_conv_clustered_model(nr_of_channels,
+                        nr_of_clusters, data_format,
+                        preserve_sparsity=True)
+    stripped_model = cluster.strip_clustering(clustered_model)
+
+    # Save the kernel weights
+    conv2d_layer = stripped_model.layers[2]
+    self.assertEqual(conv2d_layer.name, 'conv2d')
+
+    # should be nr_of_channels * nr_of_clusters
+    nr_unique_weights = -1
+
+    for weight in conv2d_layer.weights:
+      if "kernel" in weight.name:
+        nr_unique_weights = len(np.unique(weight.numpy()))
+        self.assertLessEqual(nr_unique_weights, nr_of_clusters*nr_of_channels)
+
+    # get sparsity before PCQAT training
+    # we expect that only one value will be returned
+    control_sparsity = self._get_sparsity(stripped_model)
+    self.assertGreater(control_sparsity[0], 0.5)
+
+    quant_aware_annotate_model = (
+        quantize.quantize_annotate_model(stripped_model)
+    )
+
+    quant_aware_model = quantize.quantize_apply(
+        quant_aware_annotate_model,
+        scheme=default_8bit_cluster_preserve_quantize_scheme
+        .Default8BitClusterPreserveQuantizeScheme())
+
+    # Lets train for more epochs to have a chance to scatter clusters
+    model = self._compile_and_fit_conv_model(quant_aware_model, 3)
+
+    stripped_cqat_model = strip_clustering_cqat(model)
+
+    # Check the unique weights of a certain layer of
+    # clustered_model and cqat_model
+    layer_nr = 3
+    num_of_unique_weights_cqat = self._get_number_of_unique_weights(
+        stripped_cqat_model, layer_nr, 'kernel')
+    self.assertLessEqual(num_of_unique_weights_cqat, nr_unique_weights)
+
+    # We need to do tighter check: we check that the number of unique
+    # weights per channel is less than the given nr_of_channels
+    layer = stripped_cqat_model.layers[layer_nr]
+    weight_to_check = None
+    if isinstance(layer, quantize.quantize_wrapper.QuantizeWrapper):
+      for weight_item in layer.trainable_weights:
+        if 'kernel' in weight_item.name:
+          weight_to_check = weight_item
+
+    assert weight_to_check is not None
+
+    for i in range(nr_of_channels):
+        nr_unique_weights_per_channel = len(np.unique(
+            weight_to_check[:, :, :, i]))
+        assert nr_unique_weights_per_channel == nr_of_clusters
+
+    cqat_sparsity = self._get_sparsity(stripped_cqat_model)
+    self.assertLessEqual(cqat_sparsity[0], control_sparsity[0])
 
   def testPassingNonPrunedModelToPCQAT(self):
     """Runs PCQAT as CQAT if the input model is not pruned."""

--- a/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/collaborative_optimizations/cluster_preserve/cluster_preserve_quantize_registry.py
@@ -18,6 +18,7 @@ import logging
 import tensorflow as tf
 
 from tensorflow_model_optimization.python.core.clustering.keras import clustering_registry
+from tensorflow_model_optimization.python.core.clustering.keras import cluster_config
 from tensorflow_model_optimization.python.core.quantization.keras import quant_ops
 from tensorflow_model_optimization.python.core.quantization.keras import quantizers
 from tensorflow_model_optimization.python.core.quantization.keras.default_8bit import default_8bit_quantize_registry
@@ -41,7 +42,7 @@ def get_unique(t):
   Args:
     t: tensor
   Returns:
-    unique value, lookup index (same shape as input tensor)
+    centroids (unique values), lookup index (same shape as input tensor)
   Example:
     t:
     ([[1.0, 2.0],
@@ -49,7 +50,7 @@ def get_unique(t):
       [3.0, 3.0],
       [1.0, 2.0]]
     )
-    uniques:
+    centroids(unique values):
     ([1.0, 2.0, 3.0])
     output final index:
     ([[0, 1],
@@ -62,6 +63,81 @@ def get_unique(t):
   uniques, index = tf.unique(t_flatten)
   return uniques, tf.reshape(index, shape=tf.shape(t))
 
+def max_difference(arr):
+  """ Returns maximum difference between elements in array.
+  Args:
+    arr: array with numbers
+  Returns:
+    maximum difference
+  """
+  arr_size = len(arr)
+  if arr_size == 1:
+    return 0
+
+  # Maximum difference is the difference between maximum and
+  # minimum element.
+  min_element = arr[0]
+  max_element = arr[0]
+  for i in range(1, arr_size):
+    min_element = min(arr[i], min_element)
+    max_element = max(arr[i], max_element)
+
+  return max_element - min_element
+
+def get_centroids(layer, weight, data_format):
+  """Get centroids, number of centroids and lookup index.
+  Args:
+    layer: keras layer
+    weight: tensor
+    data_format: string to indicate format: "channels_first" or "channels_last"
+  Returns:
+    centroids (unique values), number of centroids, lookup index
+  """
+  cluster_per_channel = (layer.layer and \
+    isinstance(layer.layer, tf.keras.layers.Conv2D))
+
+  if not cluster_per_channel:
+    centroids, index = get_unique(weight)
+    return centroids, tf.size(centroids), index, False
+
+  # In case of cluster_per_channel we need to extract
+  # unique values (centroids) for each channel.
+
+  num_channels = weight.shape[1] if data_format == "channels_first" \
+    else weight.shape[-1]
+
+  channel_centroids = []
+  channel_indices = []
+  num_centroids = []
+
+  for channel in range(num_channels):
+    channel_weights = weight[:,:,:,channel]
+    centroids, indices = get_unique(channel_weights)
+
+    channel_centroids.append(centroids)
+    channel_indices.append(indices)
+    num_centroids.append(tf.size(centroids))
+
+  max_centroid = max(num_centroids)
+  max_diff = max_difference(num_centroids)
+
+  if max_diff > 1:
+    centroids, index = get_unique(weight)
+    return centroids, tf.size(centroids), index, False
+
+  for i, centroid in enumerate(channel_centroids):
+    if num_centroids[i] != max_centroid:
+      one_padding = tf.ones([max_centroid - num_centroids[i]])
+      channel_centroids[i] = tf.concat([centroid, one_padding], 0)
+
+  centroids = tf.convert_to_tensor(channel_centroids)
+  lookup = tf.convert_to_tensor(channel_indices)
+
+  lookup = (tf.transpose(lookup, perm=[1, 0, 2, 3])\
+    if data_format == "channels_first"\
+    else tf.transpose(lookup, perm=[1, 2, 3, 0]))
+
+  return centroids, max_centroid, lookup, True
 
 class _ClusterPreserveInfo(object):
   """ClusterPreserveInfo."""
@@ -292,8 +368,13 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
       logging.warning(
           'Input layer does not contain zero weights, so apply CQAT instead.')
     centroids_mask = None
-    centroids, lookup = get_unique(weights)
-    num_centroids = tf.size(centroids)
+
+    # Detects whether layer is convolutional and is clustered per channel
+    data_format = getattr(layer.layer, 'data_format', None)
+    centroids, num_centroids, lookup, cluster_per_channel = \
+       get_centroids(layer,
+                     weights,
+                     data_format)
 
     if self.preserve_sparsity:
       sparsity_mask = tf.math.divide_no_nan(weights, weights)
@@ -324,8 +405,10 @@ class ClusterPreserveDefaultWeightsQuantizer(quantizers.LastValueQuantizer):
 
       # Get clustering implementation according to layer type
       clustering_impl_cls = clustering_registry.ClusteringLookupRegistry(
-          ).get_clustering_impl(layer.layer, name)
-      clustering_impl = clustering_impl_cls(clst_centroids_tf)
+          ).get_clustering_impl(layer.layer, name,
+            cluster_per_channel=cluster_per_channel)
+      clustering_impl = clustering_impl_cls(clst_centroids_tf,
+          cluster_config.GradientAggregation.SUM, data_format)
 
       pulling_indices = tf.dtypes.cast(
           clustering_impl.get_pulling_indices(ori_weights_tf),


### PR DESCRIPTION
This PR extends the existing functionality for the CQAT and PCQAT to work with the models that has been clustered using the [clustering per channel technique](https://github.com/tensorflow/model-optimization/pull/871).

<h3>Overview</h3>
The accuracy of the model in the optimization pipeline: clustering -> quantization can be improved by using the clustering per channel. Applying CQAT or PCQAT can improve accuracy further for the quantized model at the same time keeping the number of clusters and level of sparsity. The current PR allows to keep the number of clusters per channel if the model is clustered this way. 

<h3>API changes</h3>:
We don't change any APIs as we deduce whether the clustered per channel has been used based on the provided clustered model.

<h3>Testing results</h3>

 <table>
  <tr>
    <th>model</th>
    <th>baseline (float)</th>
    <th>clustered, int8</th>
    <th>clustered per channel, int8</th>
    <th>clustered, int8, CQAT</th>
    <th>clustered per channel, int8, CQAT</th>
  </tr>
  <tr>
    <td>DS-CNN-L (8 clusters)</td>
    <td>95.23 %</td>
    <td>93.453 %</td>
    <td>93.678 %</td>
    <td>95.95 %</td>
    <td>96.44 %</td>
  </tr>
  <tr>
    <td>DS-CNN-L (4 clusters)</td>
    <td>95.23 %</td>
    <td> 71.215 %</td>
    <td>89.546 %</td>
    <td>84.8%</td>
    <td>93.04 %</td>
  </tr>
<tr>
    <td>wav2letter (8 clusters)</td>
    <td>6.75 %</td>
    <td> -</td>
    <td>8.3 %</td>
    <td>-</td>
    <td>7.98 %</td>
  </tr>
<tr>
    <td>MobileNet-V2</td>
    <td>72.36%</td>
    <td> 67.634%</td>
    <td>69.53%</td>
    <td>71.538%</td>
    <td>72.638%</td>
  </tr>
</table> 

<h3>Testing results for PCQAT</h3>

 <table>
  <tr>
    <th>model</th>
    <th>baseline (float)</th>
    <th>pruned-clustered, int8</th>
    <th>pruned-clustered per channel, int8</th>
    <th>pruned-clustered, int8, PCQAT</th>
    <th>pruned-clustered per channel, int8, PCQAT</th>
  </tr>
  <tr>
    <td>MobileNet-V2</td>
    <td>72.36 %</td>
    <td>71.058 %</td>
    <td>71.058 %</td>
    <td>71.45 %</td>
    <td>71.906 %</td>   
  </tr>
</table>


