### PR TITLE
Typo Fix in Quantization Training Example

### DIFF
--- a/tensorflow_model_optimization/g3doc/guide/quantization/training_example.ipynb
+++ b/tensorflow_model_optimization/g3doc/guide/quantization/training_example.ipynb
@@ -219,7 +219,7 @@
         "\n",
         "quantize_model = tfmot.quantization.keras.quantize_model\n",
         "\n",
-        "# q_aware stands for for quantization aware.\n",
+        "# q_aware stands for quantization aware.\n",
         "q_aware_model = quantize_model(model)\n",
         "\n",
         "# `quantize_model` requires a recompile.\n",


### PR DESCRIPTION
Duplicate 'for' word in code block comment.