### PR TITLE
Added missing link to blogpost on collaborative technique.

### DIFF
--- a/tensorflow_model_optimization/g3doc/_index.yaml
+++ b/tensorflow_model_optimization/g3doc/_index.yaml
@@ -84,6 +84,12 @@ landing_page:
       - label: "Read on TensorFlow blog"
         path: https://blog.tensorflow.org/2020/04/quantization-aware-training-with-tensorflow-model-optimization-toolkit.html
 
+    - heading: "TensorFlow Model Optimization Toolkit — Collaborative Optimization API"
+      path: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html
+      buttons:
+      - label: "Read on TensorFlow blog"
+        path: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html
+
     - heading: "TensorFlow Model Optimization Toolkit - Post Training Integer Quantization"
       path: https://blog.tensorflow.org/2019/06/tensorflow-integer-quantization.html
       buttons:

--- a/tensorflow_model_optimization/g3doc/_index.yaml
+++ b/tensorflow_model_optimization/g3doc/_index.yaml
@@ -72,6 +72,12 @@ landing_page:
 
   - classname: devsite-landing-row-cards
     items:
+    - heading: "TensorFlow Model Optimization Toolkit — Collaborative Optimization API"
+      path: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html
+      buttons:
+      - label: "Read on TensorFlow blog"
+        path: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html
+
     - heading: "TensorFlow Model Optimization Toolkit - Weight Clustering API"
       path: https://blog.tensorflow.org/2020/08/tensorflow-model-optimization-toolkit-weight-clustering-api.html
       buttons:
@@ -83,12 +89,6 @@ landing_page:
       buttons:
       - label: "Read on TensorFlow blog"
         path: https://blog.tensorflow.org/2020/04/quantization-aware-training-with-tensorflow-model-optimization-toolkit.html
-
-    - heading: "TensorFlow Model Optimization Toolkit — Collaborative Optimization API"
-      path: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html
-      buttons:
-      - label: "Read on TensorFlow blog"
-        path: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html
 
     - heading: "TensorFlow Model Optimization Toolkit - Post Training Integer Quantization"
       path: https://blog.tensorflow.org/2019/06/tensorflow-integer-quantization.html


### PR DESCRIPTION
The main page on model optimizations on tensorflow.org 
https://www.tensorflow.org/model_optimization

is missing the link to the released blogpost on collaborative techniques: https://blog.tensorflow.org/2021/10/Collaborative-Optimizations.html

This PR adds the missing link.