### PR TITLE
Fix broken link in comprehensive_guide.ipynb

### DIFF
--- a/tensorflow_model_optimization/g3doc/guide/pruning/comprehensive_guide.ipynb
+++ b/tensorflow_model_optimization/g3doc/guide/pruning/comprehensive_guide.ipynb
@@ -723,7 +723,7 @@
         "id": "yqk0jI49c1mw"
       },
       "source": [
-        "Once different backends [enable pruning to improve latency]((https://github.com/tensorflow/model-optimization/issues/173)), using block sparsity can improve latency for certain hardware.\n",
+        "Once different backends [enable pruning to improve latency](https://github.com/tensorflow/model-optimization/issues/173), using block sparsity can improve latency for certain hardware.\n",
         "\n",
         "Increasing the block size will decrease the peak sparsity that's achievable for a target model accuracy. Despite this, latency can still improve.\n",
         "\n",


### PR DESCRIPTION
Remove extra parentheses in line 726 to fix the broken link.