### PR TITLE
allow registering custom layers in prune and clustering registries.

### DIFF
--- a/tensorflow_model_optimization/python/core/api/clustering/keras/__init__.py
+++ b/tensorflow_model_optimization/python/core/api/clustering/keras/__init__.py
@@ -25,4 +25,5 @@ from tensorflow_model_optimization.python.core.clustering.keras.cluster_config i
 from tensorflow_model_optimization.python.core.clustering.keras.clustering_algorithm import ClusteringAlgorithm
 from tensorflow_model_optimization.python.core.clustering.keras.clustering_callbacks import ClusteringSummaries
 from tensorflow_model_optimization.python.core.clustering.keras.clusterable_layer import ClusterableLayer
+from tensorflow_model_optimization.python.core.clustering.keras.clustering_registry import ClusteringRegistry
 # pylint: enable=g-bad-import-order

--- a/tensorflow_model_optimization/python/core/api/sparsity/keras/__init__.py
+++ b/tensorflow_model_optimization/python/core/api/sparsity/keras/__init__.py
@@ -31,4 +31,6 @@ from tensorflow_model_optimization.python.core.sparsity.keras.prunable_layer imp
 from tensorflow_model_optimization.python.core.sparsity.keras.pruning_policy import PruningPolicy
 from tensorflow_model_optimization.python.core.sparsity.keras.pruning_policy import PruneForLatencyOnXNNPack
 
+from tensorflow_model_optimization.python.core.sparsity.keras.prune_registry import PruneRegistry
+
 # pylint: enable=g-bad-import-order

--- a/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
+++ b/tensorflow_model_optimization/python/core/clustering/keras/clustering_registry.py
@@ -220,3 +220,7 @@ class ClusteringRegistry(object):
       layer.get_clusterable_weights = get_clusterable_weights
 
     return layer
+
+  @classmethod
+  def register_clusterable_layer(cls, layer: layers.Layer, clusterable_weights: list[str]):
+      cls._LAYERS_WEIGHTS_MAP[layer] = clusterable_weights

--- a/tensorflow_model_optimization/python/core/sparsity/keras/prune_registry.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/prune_registry.py
@@ -19,8 +19,6 @@ import tensorflow as tf
 
 from tensorflow_model_optimization.python.core.sparsity.keras import prunable_layer
 
-# TODO(b/139939526): move to public API.
-
 layers = tf.keras.layers
 layers_compat_v1 = tf.compat.v1.keras.layers
 
@@ -226,3 +224,7 @@ class PruneRegistry(object):
       layer.get_prunable_weights = get_prunable_weights
 
     return layer
+
+  @classmethod
+  def register_prunable_layer(cls, layer: layers.Layer, prunable_weights: list[str]):
+    cls._LAYERS_WEIGHTS_MAP[layer] = prunable_weights


### PR DESCRIPTION
Hi team `tensorflow-model-optimization`, 
I was applying clustering and pruning to a model based on Bert encoder from `tensorlfow-models-official`, 
and noticed that there is no API for registering custom layers, so here is a PR, which adds it.

#### Implemented changes

- Allow registering custom layers in `PruneRegistry` and `ClusteringRegistry`
- Export `PruneRegistry` and `ClusteringRegistry` as part of public API.
