### PR TITLE
Extract _clone_model_with_weights from quantize_apply

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/quantize.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/quantize.py
@@ -285,6 +285,13 @@ def quantize_annotate_layer(to_annotate, quantize_config=None):
       layer=to_annotate, quantize_config=quantize_config)
 
 
+def _clone_model_with_weights(model_to_clone):
+  cloned_model = keras.models.clone_model(model_to_clone)
+  cloned_model.set_weights(model_to_clone.get_weights())
+
+  return cloned_model
+
+
 @metrics.MonitorBoolGauge('quantize_apply_usage')
 def quantize_apply(
     model,
@@ -360,12 +367,6 @@ def quantize_apply(
     raise ValueError('`model` must be a built model. '
                      'been built yet. Please call `model.build(input_shape)` '
                      'before quantizing your model.')
-
-  def _clone_model_with_weights(model_to_clone):
-    cloned_model = keras.models.clone_model(model_to_clone)
-    cloned_model.set_weights(model_to_clone.get_weights())
-
-    return cloned_model
 
   def _extract_original_model(model_to_unwrap):
     """Extracts original model by removing wrappers."""


### PR DESCRIPTION
This aids downstream repos that implement fixes for various cloning issues by making this function able to be monkey-patched.

For context, I am part of @hunse's team that is affected by #994. We are successfully using the workaround that he posted in his final comment. However, in order to implement that workaround we have to copy/paste the entirety of `quantize_apply` in our project to monkey-patch it. While it works, it's a brittle solution as we will have to update our copied `quantize_apply` when it changes in this repo.

While we are happy to make a pull request with our full fix, it will add to your maintenance burden, so we thought that we would instead start off with this very minimal change that will not increase your maintenance burden, but still allow us to do a minor surgical monkey patch that requires no copy/pasting in our project. If you would like us to instead or in addition contribute that fix, please let me know (but since #994 has not received the "contributions welcome" tag, I assume it is not of interest at the moment).