### PR TITLE
add original weight name as prefix for mask and threshold weights

### DIFF
--- a/tensorflow_model_optimization/python/core/sparsity/keras/pruning_wrapper.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/pruning_wrapper.py
@@ -233,14 +233,14 @@ class PruneLowMagnitude(Wrapper):
     # For each of the prunable weights, add mask and threshold variables
     for weight in self.prunable_weights:
       mask = self.add_weight(
-          'mask',
+          weight.name + '_mask',
           shape=weight.shape,
           initializer=tf.keras.initializers.get('ones'),
           dtype=weight.dtype,
           trainable=False,
           aggregation=tf.VariableAggregation.MEAN)
       threshold = self.add_weight(
-          'threshold',
+          weight.name + '_threshold',
           shape=[],
           initializer=tf.keras.initializers.get('zeros'),
           dtype=weight.dtype,


### PR DESCRIPTION
If there are multiple prunable weights in a wrapped layer, without this change, the wrapped model cannot be saved to h5 because of duplicate dataset names (the layer has multiple weights called "mask" and "threshold").

There are certainly other ways to solve this issue, but this felt like the most straight forward. Feel free, to improve.


solves #1077