### PR TITLE
remove early out in xnnpack pruning policy model traversal

### DIFF
--- a/tensorflow_model_optimization/python/core/sparsity/keras/pruning_policy.py
+++ b/tensorflow_model_optimization/python/core/sparsity/keras/pruning_policy.py
@@ -124,8 +124,6 @@ class PruneForLatencyOnXNNPack(PruningPolicy):
         found_layers.add(layer)
       else:
         next_layers = next_fn(layer)
-        if not next_layers:
-          return set()
         for next_layer in next_layers:
           if next_layer not in used_layers:
             used_layers.add(next_layer)


### PR DESCRIPTION
If there are multiple input layers (and therefore paths), this early out might return an empty set before all paths are checked. By simply removing it, the path that doesn't have a next layer ends, nothing is added to the `found_layers` and the other paths continue to be checked.

I stumbled upon this with a model that had multiple inputs, one of which was feeding directly into the last (custom) layer. As soon as the traversal found no next layer after it, I got the error message of no valid input branch:
> *'Could not find `Conv2D 3x3` layer with stride 2x2, `input filters == 3` and `VALID` padding and preceding `ZeroPadding2D` with `padding == 1` in all input branches of the model'*