### PR TITLE
Fix model loading from .keras files in Tensorflow 2.15

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/quantize_layer.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/quantize_layer.py
@@ -54,6 +54,7 @@ class QuantizeLayer(keras.layers.Layer):
     self.quantizer = quantizer
 
   def build(self, input_shape):
+    super(QuantizeLayer, self).build(input_shape)
     if self.quantizer:
       self.quantizer_vars = self.quantizer.build(
           input_shape, self.name, self)

--- a/tensorflow_model_optimization/python/core/quantization/keras/quantize_wrapper.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/quantize_wrapper.py
@@ -252,8 +252,8 @@ class QuantizeWrapper(keras.layers.Wrapper):
 class QuantizeWrapperV2(QuantizeWrapper):
 
   def build(self, input_shape):
-    self._trainable_weights.extend(self.layer.trainable_weights)
     super(QuantizeWrapperV2, self).build(input_shape)
+    self._trainable_weights = self.layer.trainable_weights + self._trainable_weights
 
   @property
   def trainable_weights(self):


### PR DESCRIPTION
When loading models from .keras files, quantize layer weight number does not match stored number of weights as layer is build twice. 
In addition, the QuantizeWrapperV2 does not populate the base layer weights correctly as the order of calls seems off.