### PR TITLE
fix(quantize_registry): compare activation_attrs against other, not self, in QuantizeConfig.__eq__

### DIFF
--- a/tensorflow_model_optimization/python/core/quantization/keras/default_8bit/default_8bit_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/default_8bit/default_8bit_quantize_registry.py
@@ -366,7 +366,7 @@ class Default8BitQuantizeConfig(QuantizeConfig):
       return False
 
     return (self.weight_attrs == other.weight_attrs and
-            self.activation_attrs == self.activation_attrs and
+            self.activation_attrs == other.activation_attrs and
             self.weight_quantizer == other.weight_quantizer and
             self.activation_quantizer == other.activation_quantizer and
             self.quantize_output == other.quantize_output)

--- a/tensorflow_model_optimization/python/core/quantization/keras/experimental/default_n_bit/default_n_bit_quantize_registry.py
+++ b/tensorflow_model_optimization/python/core/quantization/keras/experimental/default_n_bit/default_n_bit_quantize_registry.py
@@ -412,7 +412,7 @@ class DefaultNBitQuantizeConfig(QuantizeConfig):
       return False
 
     return (self.weight_attrs == other.weight_attrs and
-            self.activation_attrs == self.activation_attrs and
+            self.activation_attrs == other.activation_attrs and
             self.weight_quantizer == other.weight_quantizer and
             self.activation_quantizer == other.activation_quantizer and
             self.quantize_output == other.quantize_output)


### PR DESCRIPTION
### Problem

`Default8BitQuantizeConfig.__eq__` and `DefaultNBitQuantizeConfig.__eq__` compare `activation_attrs` against **`self`** instead of `other`:

```python
  def __eq__(self, other):
    if not isinstance(other, Default8BitQuantizeConfig):
      return False

    return (self.weight_attrs == other.weight_attrs and
            self.activation_attrs == self.activation_attrs and   # <-- always True
            self.weight_quantizer == other.weight_quantizer and
            self.activation_quantizer == other.activation_quantizer and
            self.quantize_output == other.quantize_output)
```

`self.activation_attrs == self.activation_attrs` is always `True`, so the term contributes nothing to the `and` chain: **`activation_attrs` is effectively excluded from equality**, and two configs that differ only in which activations they quantize compare equal (and `__ne__`, which delegates to `__eq__`, reports them as not-unequal).

Every one of the four sibling terms in the same expression compares `self.X == other.X`, and every other `__eq__` in the package follows that idiom — e.g. `LastValueQuantizer.__eq__` in `quantizers.py`:

```python
    return (self.num_bits == other.num_bits and
            self.per_axis == other.per_axis and
            self.symmetric == other.symmetric and
            self.narrow_range == other.narrow_range)
```

The same line is duplicated verbatim in the `default_n_bit` copy, so both are fixed here.

- `default_8bit/default_8bit_quantize_registry.py:369`
- `experimental/default_n_bit/default_n_bit_quantize_registry.py:415`

### Fix

`self.activation_attrs == self.activation_attrs` → `self.activation_attrs == other.activation_attrs`, in both files. Two lines, no other change.

### Verification

I don't have a TF runtime on this box, so I verified behaviourally by extracting `__eq__` verbatim from the file with `ast.get_source_segment`, `exec`-ing it against a minimal stand-in that only holds the five compared attributes, and running the current line against the patched one:

| case | expected | master | patched |
|---|---|---|---|
| differs only in `activation_attrs` | `False` | **`True`** ❌ | `False` ✅ |
| identical | `True` | `True` | `True` |
| differs in `weight_attrs` (control) | `False` | `False` | `False` |
| empty vs non-empty `activation_attrs` | `False` | **`True`** ❌ | `False` ✅ |

The control row is there to show the check isn't vacuous: `weight_attrs`, which is compared correctly, already discriminates on master, and the patch leaves it alone. Only the two rows that isolate `activation_attrs` change.

A concrete pair that is wrongly equal on master:

```python
a = Default8BitQuantizeConfig(['kernel'], ['activation'], False)
b = Default8BitQuantizeConfig(['kernel'], ['recurrent_activation'], False)
a == b   # True on master, False with this patch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
